### PR TITLE
Factor out behaviors from `start()` main loop

### DIFF
--- a/src/zinoargus/__init__.py
+++ b/src/zinoargus/__init__.py
@@ -45,7 +45,7 @@ _config: Configuration = None
 _zino: ritz.ritz = None
 _notifier: ritz.notifier = None
 _argus: Client = None
-_metadata = dict()
+_circuit_metadata = dict()
 
 
 def main():
@@ -125,8 +125,7 @@ def start():
     connections or API's fail.
     """
     _logger.info("starting")
-    # Collect circuit metadata
-    collect_metadata()
+    collect_circuit_metadata()
 
     argus_incidents, zino_cases = synchronize_all_cases()
     synchronize_continuously(argus_incidents, zino_cases)
@@ -282,8 +281,8 @@ def synchronize_continuously(argus_incidents: IncidentMap, zino_cases: CaseMap):
         # TODO: Pri1 next time :)
 
 
-def collect_metadata():
-    global _metadata
+def collect_circuit_metadata():
+    global _circuit_metadata
     global _config
 
     metadata_url = _config.metadata.ports_url
@@ -295,7 +294,7 @@ def collect_metadata():
     r2 = r.json()
     _logger.info("Collected metadata for %s routers", len(r2["data"]))
     _logger.info(r2["data"].keys())
-    _metadata = r2["data"]
+    _circuit_metadata = r2["data"]
 
 
 def is_down_log(log):

--- a/src/zinoargus/__init__.py
+++ b/src/zinoargus/__init__.py
@@ -181,11 +181,13 @@ def start():
     _logger.debug("List of open incidents: ")
     for inciedent in argus_incidents:
         _logger.debug(inciedent)
+    for incident in argus_incidents:
+        _logger.debug(incident)
 
     while True:
         update = _notifier.poll(timeout=1)
         if not update:
-            # No notification recieved
+            # No notification received
             continue
         print(
             'Update on case id:"{}" type:"{}" info:"{}"'.format(

--- a/src/zinoargus/__init__.py
+++ b/src/zinoargus/__init__.py
@@ -19,6 +19,7 @@ import logging
 import signal
 import sys
 from datetime import datetime
+from typing import Optional
 
 import requests
 import zinolib as ritz
@@ -41,10 +42,10 @@ _logger = logging.getLogger("zinoargus")
 
 FORMATTER = logging.Formatter("%(asctime)s - %(name)s - %(levelname)s - %(message)s")
 
-_config: Configuration = None
-_zino: ritz.ritz = None
-_notifier: ritz.notifier = None
-_argus: Client = None
+_config: Optional[Configuration] = None
+_zino: Optional[ritz.ritz] = None
+_notifier: Optional[ritz.notifier] = None
+_argus: Optional[Client] = None
 _circuit_metadata = dict()
 
 


### PR DESCRIPTION
This mainly breaks down the over-100-lines long `start()` function into smaller, more manageable functions, with clear names, hopefully making the code easier to read (and test).

There also some small typo and type annotation fixes.

Depends on #6 
