### PR TITLE
Run tests and publish results in workflows

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,28 @@
+name: Run tests
+
+on:
+  push:
+    branches:
+      - master
+      - 'test/*'
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ['3.9', '3.10', '3.11', '3.12']
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Install tox
+        run: pip install tox
+
+      - name: Test
+        run: tox -e py

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -26,3 +26,11 @@ jobs:
 
       - name: Test
         run: tox -e py
+
+      - name: Upload test reports (${{ matrix.python-version }})
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: test-reports-${{ matrix.python-version }}
+          path: |
+            reports/**/*

--- a/.github/workflows/publish-test-results.yml
+++ b/.github/workflows/publish-test-results.yml
@@ -1,0 +1,36 @@
+name: Publish test results
+
+on:
+  workflow_run:
+    workflows: ["Run tests"]
+    types:
+      - completed
+
+jobs:
+  publish-test-results:
+    name: "Publish test results"
+    runs-on: ubuntu-latest
+    if: github.event.workflow_run.conclusion != 'skipped' && github.repository_owner == 'Uninett'
+
+    steps:
+      - name: Download and Extract Artifacts
+        env:
+          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
+        run: |
+           mkdir -p artifacts && cd artifacts
+
+           artifacts_url=${{ github.event.workflow_run.artifacts_url }}
+
+           gh api "$artifacts_url" -q '.artifacts[] | [.name, .archive_download_url] | @tsv' | while read artifact
+           do
+             IFS=$'\t' read name url <<< "$artifact"
+             gh api $url > "$name.zip"
+             unzip -o -d "$name" "$name.zip"
+           done
+
+      - name: "Publish test results"
+        uses: EnricoMi/publish-unit-test-result-action@v2
+        with:
+          commit: ${{ github.event.workflow_run.head_sha }}
+          check_name: "Test results"
+          files: artifacts/**/*-results.xml


### PR DESCRIPTION
Add workflows to automatically run tests and publish results on pushes and pull requests.

The test publisher workflow needs to be present on the `master` branch before it will run, since it's triggered by the completion of a branch-local workflow.