### PR TITLE
Factor out Zino and Argus connection from `main()`

### DIFF
--- a/src/zinoargus/__init__.py
+++ b/src/zinoargus/__init__.py
@@ -32,6 +32,7 @@ from zinoargus.config import (
     read_configuration,
 )
 from zinoargus.config.models import (
+    ArgusConfiguration,
     Configuration,
     ZinoConfiguration,
 )
@@ -77,10 +78,7 @@ def main():
     signal.signal(signal.SIGINT, signal_handler)
     signal.signal(signal.SIGTERM, signal_handler)
 
-    _argus = Client(
-        api_root_url=str(_config.argus.url),
-        token=_config.argus.token,
-    )
+    _argus = get_argus_client(_config.argus)
 
     """Initiate connectionloop to zino"""
     try:
@@ -128,6 +126,14 @@ def connect_to_zino(
     zino.connect()
     notifier = zino.init_notifier()
     return zino, notifier
+
+
+def get_argus_client(configuration: ArgusConfiguration) -> Client:
+    """Returns a new Argus client instance"""
+    return Client(
+        api_root_url=str(configuration.url),
+        token=configuration.token,
+    )
 
 
 def start():

--- a/src/zinoargus/__init__.py
+++ b/src/zinoargus/__init__.py
@@ -233,10 +233,11 @@ def synchronize_continuously(argus_incidents: IncidentMap, zino_cases: CaseMap):
         if not update:
             # No notification received
             continue
-        print(
-            'Update on case id:"{}" type:"{}" info:"{}"'.format(
-                update.id, update.type, update.info
-            )
+        _logger.debug(
+            "Update on Zino case id:%s type:%s info:%s",
+            update.id,
+            update.type,
+            update.info,
         )
         if update.type == "state":
             old_state, new_state = update.info.split(" ", 1)


### PR DESCRIPTION
Factors out some more functionality to better enable testing and re-use.

Also fixes some weird print vs log behavior.

Depends on #9 