### PR TITLE
Set correct timezone on timestamps from Zino

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ Notable changes to the library will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- Handle timezones correctly when passing timestamps from Zino to Argus.
+
 ## [0.2.0] - 2025-07-25
 
 ### Added


### PR DESCRIPTION
Due to a misunderstanding of how zinolib works, timestamps were sent to Argus with incorrect timezone information. The datetime objects returned from zinolib are indeed timezone-naive, but it turns out they are converted from Zino's UTC-based UNIX timestamps using `datetime.fromtimestamp()`, which actually converts the timestamps into local time. Assigning the UTC timezone directly to these datetime objects is therefore wrong - they must be assigned the current timezone of the system, or there will be weird discrepancies when looking at Argus.