### PR TITLE
Keep track of changes to all incidents created by glue service

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Handle timezones correctly when passing timestamps from Zino to Argus.
+- Properly follow up on state changes in all Argus incidents created by this
+  glue service.
 
 ## [0.2.0] - 2025-07-25
 

--- a/src/zinoargus/__init__.py
+++ b/src/zinoargus/__init__.py
@@ -222,13 +222,18 @@ def get_all_interesting_zino_cases() -> CaseMap:
     return zino_cases
 
 
-def create_argus_incidents_from_new_zino_cases(argus_incidents, zino_cases):
+def create_argus_incidents_from_new_zino_cases(
+    argus_incidents: IncidentMap, zino_cases: CaseMap
+):
     for case_id in set(zino_cases) - set(argus_incidents):
         _logger.info("Zino case %s is not in Argus, creating", case_id)
-        create_argus_incident(zino_cases[case_id])
+        new_incident = create_argus_incident(zino_cases[case_id])
+        argus_incidents[case_id] = new_incident
 
 
-def close_argus_incidents_missing_from_zino(argus_incidents, zino_cases):
+def close_argus_incidents_missing_from_zino(
+    argus_incidents: IncidentMap, zino_cases: CaseMap
+):
     for case_id in set(argus_incidents) - set(zino_cases):
         _logger.info(
             "Zino case %s is not cached from Zino, and ready to be closed in Argus",
@@ -439,7 +444,9 @@ def get_or_make_argus_incident_for_zino_case(
         argus_incidents[case_id] = incident
         return incident
 
-    return create_argus_incident(case)
+    new_incident = create_argus_incident(case)
+    argus_incidents[case_id] = new_incident
+    return new_incident
 
 
 def update_state(


### PR DESCRIPTION
The internal incident-to-case map was only properly updated on glue service startup, and was not kept up to date as new incidents were created.  This ensures they are mapped as they are added.
