### PR TITLE
Close Zino event if Argus incident was closed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Added config option `timeout` to configure the Argus API timeout
 
+### Fixed
+- Close a Zino event if the corresponding Argus incident was closed.
+
 ## [0.2.1] - 2025-09-04
 
 ### Fixed


### PR DESCRIPTION
Closes #21 and closes #24. 

Manually tested and works well.

The only funny side effect I realized is that since in #12 it was added that the Zino case log will be copied to Argus, when closing an event in Argus (which in turn adds a log entry to Zino) that closing message is then synced back to Argus from Zino. Do we think that is a problem?  