### PR TITLE
Add workflows for formatting/linting with ruff

### DIFF
--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -1,0 +1,20 @@
+name: Verify formatting
+
+on:
+  push:
+    branches:
+      - master
+      - 'test/*'
+  pull_request:
+
+jobs:
+  ruff:
+    runs-on: ubuntu-latest
+    name: Verify Python formatting
+    steps:
+    - uses: actions/checkout@v5
+
+    - uses: astral-sh/ruff-action@v3
+      with:
+        version: "0.13.0"
+        args: "format --check"

--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -1,0 +1,17 @@
+name: Linting
+on:
+  push:
+    branches:
+      - master
+      - 'test/*'
+  pull_request:
+
+jobs:
+  ruff:
+    runs-on: ubuntu-latest
+    name: Lint Python
+    steps:
+    - uses: actions/checkout@v5
+    - uses: astral-sh/ruff-action@v3
+      with:
+        version: "0.13.0"

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
 -   repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v5.0.0
+    rev: v6.0.0
     hooks:
     -   id: trailing-whitespace
     -   id: mixed-line-ending
@@ -8,7 +8,7 @@ repos:
         exclude: &exclude_pattern '^changelog.d/'
     -   id: debug-statements
 -   repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.10.0
+    rev: v0.13.0
     hooks:
         # Run the linter
     -   id: ruff

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,29 +57,6 @@ exclude = ["tests*"]
 [tool.setuptools_scm]
 write_to = "src/zinoargus/version.py"
 
-[tool.black]
-line-length = 88
-# Exclude files even when passed directly as argument (for MegaLinter)
-force-exclude = '''
-(
-  /(
-      \.eggs         # exclude a few common directories in the
-    | \.git          # root of the project
-    | \.hg
-    | \.mypy_cache
-    | \.nox
-    | \.tox
-    | \.venv
-    | \.ve
-    | _build
-    | buck-out
-    | build
-    | dist
-    | docs
-  )
-)
-'''
-
 [tool.ruff]
 line-length = 88
 target-version = "py311"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,11 +60,9 @@ write_to = "src/zinoargus/version.py"
 [tool.ruff]
 line-length = 88
 target-version = "py311"
-exclude = [
+extend-exclude = [
     "docs"
 ]
-# Exclude files even when passed directly as argument (for MegaLinter)
-force-exclude = true
 
 [tool.coverage.report]
 # Regexes for lines to exclude from consideration

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -63,6 +63,9 @@ target-version = "py311"
 extend-exclude = [
     "docs"
 ]
+[tool.ruff.lint]
+select = ["E4", "E7", "E9", "F", "I"]
+fixable = ["I"]
 
 [tool.coverage.report]
 # Regexes for lines to exclude from consideration


### PR DESCRIPTION
And some other small things:
- removing the black configuration
- removing config adaptations we made for MegaLinter
- use isort rules in ruff
- upgrade pre-commit hooks