### PR TITLE
Add config option to configure Argus API timeout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ Notable changes to the library will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+- Added config option `timeout` to configure the Argus API timeout
+
 ## [0.2.1] - 2025-09-04
 
 ### Fixed

--- a/src/zinoargus/__init__.py
+++ b/src/zinoargus/__init__.py
@@ -141,6 +141,7 @@ def get_argus_client(configuration: ArgusConfiguration) -> Client:
     return Client(
         api_root_url=str(configuration.url),
         token=configuration.token,
+        timeout=configuration.timeout,
     )
 
 

--- a/src/zinoargus/config/models.py
+++ b/src/zinoargus/config/models.py
@@ -18,7 +18,7 @@
 
 from typing import Literal, Optional, Union
 
-from pydantic import AnyHttpUrl, BaseModel, ConfigDict, IPvAnyAddress
+from pydantic import AnyHttpUrl, BaseModel, ConfigDict, IPvAnyAddress, PositiveFloat
 
 Host = Union[IPvAnyAddress, str]
 
@@ -31,6 +31,7 @@ class ArgusConfiguration(BaseModel):
 
     url: AnyHttpUrl
     token: str
+    timeout: PositiveFloat = 2.0
 
 
 class ZinoConfiguration(BaseModel):

--- a/src/zinoargus/config/models.py
+++ b/src/zinoargus/config/models.py
@@ -26,6 +26,7 @@ Host = Union[IPvAnyAddress, str]
 class ArgusConfiguration(BaseModel):
     """Argus API connection configuration"""
 
+    # throw ValidationError on extra keys
     model_config = ConfigDict(extra="forbid")
 
     url: AnyHttpUrl

--- a/zinoargus.toml.example
+++ b/zinoargus.toml.example
@@ -4,6 +4,10 @@
 url = "https://path.to.api/api/v2/"
 token = "1234543654778675647436245234"
 
+# Timeout for Argus API requests
+# default 2.0 seconds
+timeout = 2.0
+
 [zino]
 # The configuration used to establish a zino server session
 server = "zino.server"


### PR DESCRIPTION
Closes #25.

Reference for `PositiveFloat` Pydantic type: https://docs.pydantic.dev/2.3/api/types/#pydantic.types.PositiveFloat