### PR TITLE
Avoid syncing back history entries added by us

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - Close a Zino event if the corresponding Argus incident was closed.
+- Avoid syncing back Zino history entries added by the glue service.
 
 ## [0.2.1] - 2025-09-04
 


### PR DESCRIPTION
As mentioned in #22.

Now we still get events from Zino that are `state change open -> closed (user1) zino @ Oct. 2, 2025, 1:34 p.m.`  - should we also filter those out or is it nice to get a confirmation that the case was also closed in Zino?