### PR TITLE
Add towncrier to produce the changelog

### DIFF
--- a/.github/workflows/towncrier.yml
+++ b/.github/workflows/towncrier.yml
@@ -1,0 +1,24 @@
+name: Check for changelog file
+
+on:
+  pull_request:
+      # labeled/unlabeled = label is added/removed
+      # synchronize = PR's head branch was updated
+      types: [labeled, unlabeled, opened, reopened, synchronize]
+
+jobs:
+  towncrier:
+    if: ${{ github.actor != 'dependabot[bot]' && !contains(github.event.pull_request.labels.*.name, 'nonews') && !contains(github.event.pull_request.labels.*.name, 'github_actions') }}
+    runs-on: ubuntu-latest
+    name: Towncrier check
+    steps:
+    - uses: actions/checkout@v5
+      with:
+        fetch-depth: 0
+
+    - name: Install towncrier
+      run: |
+        sudo apt-get install -y pipx
+        pipx install towncrier
+    - name: Check for changelog file
+      run: towncrier check --compare-with origin/master

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ Notable changes to the library will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+This project uses [*towncrier*](https://towncrier.readthedocs.io/) and the changes for
+the upcoming release can be found in
+<https://github.com/Uninett/zino-argus-glue/tree/master/changelog.d/>.
+
+<!-- towncrier release notes start -->
+
 ## [0.3.0] - 2025-10-21
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -57,3 +57,49 @@ Research)
 
 Licensed under the Apache License, Version 2.0; See [LICENSE](./LICENSE) for a
 full copy of the License.
+
+## Developing Zino-Argus-Glue
+
+### Using towncrier to automatically produce the changelog
+#### Before merging a pull request
+To be able to automatically produce the changelog for a release one file for each
+pull request (also called news fragment) needs to be added to the folder
+`changelog.d/`.
+
+The name of the file consists of three parts separated by a period:
+1. The identifier: the issue number
+or the pull request number. If we don't want to add a link to the resulting changelog
+entry then a `+` followed by a unique short description.
+2. The type of the change: we use `security`, `removed`, `deprecated`, `added`,
+`changed` and `fixed`.
+3. The file suffix, e.g. `.md`, towncrier does not care which suffix a fragment has.
+
+So an example for a file name related to an issue/pull request would be `214.added.md`
+or for a file without corresponding issue `+fixed-pagination-bug.fixed.md`.
+
+This file can either be created manually with a file name as specified above and the
+changelog text as content or one can use towncrier to create such a file as following:
+
+```console
+$ towncrier create -c "Changelog content" 214.added.md
+```
+
+When opening a pull request there will be a check to make sure that a news fragment is
+added and it will fail if it is missing.
+
+#### Before a release
+To add all content from the `changelog.d/` folder to the changelog file simply run
+```console
+$ towncrier build --version {version}
+```
+This will also delete all files in `changelog.d/`.
+
+To preview what the addition to the changelog file would look like add the flag
+`--draft`. This will not delete any files or change `CHANGELOG.md`. It will only output
+the preview in the terminal.
+
+A few other helpful flags:
+- `date DATE` - set the date of the release, default is today
+- `keep` - do not delete the files in `changelog.d/`
+
+More information about [towncrier](https://towncrier.readthedocs.io).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,6 +37,24 @@ dynamic = ["version"]
 [project.scripts]
 zinoargus = "zinoargus:main"
 
+[dependency-groups]
+test = [
+    "coverage",
+    "pytest>7",
+    "pytest-cov",
+    "tox",
+]
+maintenance = [
+    "build",
+    "twine",
+]
+dev = [
+    "ruff",
+    "pre-commit",
+    {include-group = "maintenance"},
+    {include-group = "test"},
+]
+
 [tool.setuptools]
 include-package-data = true
 zip-safe = false

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,6 +47,7 @@ test = [
 maintenance = [
     "build",
     "twine",
+    "towncrier",
 ]
 dev = [
     "ruff",
@@ -100,3 +101,42 @@ exclude_also = [
 markers = [
     "slow: marks tests as slow (deselect with '-m \"not slow\"')"
 ]
+
+[tool.towncrier]
+directory = "changelog.d"
+filename = "CHANGELOG.md"
+start_string = "<!-- towncrier release notes start -->\n"
+underlines = ["", "", ""]
+title_format = "## [{version}] - {project_date}"
+issue_format = "[#{issue}](https://github.com/Uninett/zino/issues/{issue})"
+wrap = false
+
+[[tool.towncrier.type]]
+directory = "security"
+name = "Security"
+showcontent = true
+
+[[tool.towncrier.type]]
+directory = "removed"
+name = "Removed"
+showcontent = true
+
+[[tool.towncrier.type]]
+directory = "deprecated"
+name = "Deprecated"
+showcontent = true
+
+[[tool.towncrier.type]]
+directory = "added"
+name = "Added"
+showcontent = true
+
+[[tool.towncrier.type]]
+directory = "changed"
+name = "Changed"
+showcontent = true
+
+[[tool.towncrier.type]]
+directory = "fixed"
+name = "Fixed"
+showcontent = true


### PR DESCRIPTION
As talked about with @lunkwill42 in yesterdays meeting, adding towncrier to have the same development flow as in our other projects. 