### PR TITLE
Clean up project dependencies

### DIFF
--- a/changelog.d/+argus2.changed.md
+++ b/changelog.d/+argus2.changed.md
@@ -1,0 +1,1 @@
+Test on Argus 2.x by default

--- a/changelog.d/+dep-groups.changed.md
+++ b/changelog.d/+dep-groups.changed.md
@@ -1,0 +1,1 @@
+Move dev and test dependencies from requirements files into `[dependency-groups]` in `pyproject.toml`

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,7 +41,7 @@ zinoargus = "zinoargus:main"
 test = [
     "coverage",
     "pytest>7",
-    "pytest-argus-server>=0.2.0",
+    "pytest-argus-server>=0.3.0",
     "pytest-cov",
     "tox",
     "zino>=2.0.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,8 +41,10 @@ zinoargus = "zinoargus:main"
 test = [
     "coverage",
     "pytest>7",
+    "pytest-argus-server>=0.2.0",
     "pytest-cov",
     "tox",
+    "zino>=2.0.0",
 ]
 maintenance = [
     "build",

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,5 +1,0 @@
-pre-commit
-pytest
-pytest-cov
-ruff
-towncrier

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -7,11 +7,9 @@ import time
 
 import pytest
 
-
-def pytest_configure(config):
-    # This forces an argus version that works (as of this writing, the latest
-    # docker images are broken)
-    config.option.argus_version = "1.30.0"
+# def pytest_configure(config):
+#     # This forces a specific Argus version, if needed
+#     config.option.argus_version = "2.7.0"
 
 
 @pytest.fixture

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,4 +1,0 @@
-pytest
-pytest-cov
-pytest-argus-server>=0.2.0
-zino>=2.0.0

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,9 @@
 [tox]
+requires =
+    tox >= 4.22
+min_version = 4.22
 envlist =
     py{39,310,311,312}
-skipsdist = True
 skip_missing_interpreters = True
 basepython = python3.11
 
@@ -13,9 +15,7 @@ python =
     3.12: py312
 
 [testenv]
-deps =
-    .
-    -r tests/requirements.txt
+dependency_groups = test
 
 setenv =
     LC_ALL=C.UTF-8


### PR DESCRIPTION
This moves all test and development requirements files into `pyproject.toml` dependency groups.

It also updates dependencies related to Argus, in order to ensure we test against Argus 2.x.