### PR TITLE
Add failover support for primary/secondary deployments

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,9 +50,41 @@ or you can specify an alternate path to a configuration file using the `-c`
 command line option.  See [zinoargus.toml.example](./zinoargus.toml.example)
 for an example configuration file.
 
+## Primary/secondary failover
+
+`zino-argus-glue` can run as a secondary instance that monitors a primary Zino
+server and only takes over Argus synchronization only when the primary becomes
+unreachable.  The secondary polls the primary's SNMP agent for its uptime at
+regular intervals; after a configurable number of consecutive failures it
+switches from `STANDBY` to `ACTIVE` and begins syncing.  When the primary
+recovers (the same number of consecutive successes), it switches back to
+STANDBY.
+
+To enable failover, add a `[failover]` section to your configuration file:
+
+```toml
+[failover]
+primary_server = "10.0.0.1"
+primary_snmp_port = 8000
+snmp_community = "public"
+ping_timeout = 5
+threshold = 10
+```
+
+- `primary_server` — hostname or IP of the primary Zino's SNMP agent
+  (required)
+- `primary_snmp_port` — UDP port of the SNMP agent (default `8000`)
+- `snmp_community` — SNMP community string (default `"public"`)
+- `ping_timeout` — timeout in seconds for each SNMP query (default `5`)
+- `threshold` — number of consecutive failures before activating, and
+  consecutive successes before standing down (default `10`)
+
+When the `[failover]` section is omitted, the daemon runs in standalone
+(always-active) mode, which is the default behavior.
+
 ## Copying
 
-Copyright 2025 Sikt (The Norwegian Agency for Shared Services in Education and
+Copyright 2025-2026 Sikt (The Norwegian Agency for Shared Services in Education and
 Research)
 
 Licensed under the Apache License, Version 2.0; See [LICENSE](./LICENSE) for a

--- a/README.md
+++ b/README.md
@@ -60,6 +60,12 @@ switches from `STANDBY` to `ACTIVE` and begins syncing.  When the primary
 recovers (the same number of consecutive successes), it switches back to
 STANDBY.
 
+A complete failover deployment therefore consists of two independent Zino
+servers (each with its own state) and two `zino-argus-glue` instances.  Each
+glue instance connects to its own local Zino, and the secondary glue
+additionally pings the *primary* Zino's SNMP agent to decide whether to be
+active.
+
 To enable failover, add a `[failover]` section to your configuration file:
 
 ```toml
@@ -81,6 +87,22 @@ threshold = 10
 
 When the `[failover]` section is omitted, the daemon runs in standalone
 (always-active) mode, which is the default behavior.
+
+### Verifying failover manually
+
+To exercise the failover logic end-to-end:
+
+1. Start the secondary `zino-argus-glue` with a `[failover]` section pointing
+   at the primary Zino's SNMP agent.  It should log that it is starting in
+   `STANDBY` mode.
+2. Stop the primary Zino process.  After `threshold` consecutive ping failures
+   the secondary should log a transition to `ACTIVE` and begin syncing its
+   own Zino's cases to Argus.
+3. Restart the primary Zino.  After `threshold` consecutive successful pings
+   the secondary should log a transition back to `STANDBY` and stop syncing.
+
+A low `threshold` (e.g. `3`) is convenient for testing; production deployments
+will typically want a higher value to avoid flapping.
 
 ## Copying
 

--- a/changelog.d/30.added.md
+++ b/changelog.d/30.added.md
@@ -1,0 +1,1 @@
+Added failover mechanism for primary/secondary Zino deployments. A secondary instance monitors the primary via SNMP and only syncs to Argus when the primary is unreachable.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,6 +23,7 @@ classifiers = [
 ]
 dependencies = [
     "argus-api-client",
+    "pysnmp~=6.2",
     "requests",
     "pydantic<2.11",
     "zinolib>=1.3.4",

--- a/src/zinoargus/__init__.py
+++ b/src/zinoargus/__init__.py
@@ -38,6 +38,7 @@ from zinoargus.config.models import (
     Configuration,
     ZinoConfiguration,
 )
+from zinoargus.failover import InstanceState
 
 # A map of Zino case numbers to Zino case objects
 CaseMap = dict[int, ritz.Case]
@@ -153,8 +154,16 @@ def start():
     _logger.info("starting")
     collect_circuit_metadata()
 
-    argus_incidents, zino_cases = synchronize_all_cases()
-    synchronize_continuously(argus_incidents, zino_cases)
+    instance = InstanceState(_config.failover)
+
+    if instance.is_active:
+        argus_incidents, zino_cases = synchronize_all_cases()
+    else:
+        _logger.info("Starting in STANDBY mode, skipping initial Argus sync")
+        argus_incidents = {}
+        zino_cases = get_all_interesting_zino_cases()
+
+    synchronize_continuously(argus_incidents, zino_cases, instance)
 
 
 def synchronize_all_cases() -> tuple[IncidentMap, CaseMap]:
@@ -250,14 +259,18 @@ def close_argus_incidents_missing_from_zino(
         )
 
 
-def synchronize_continuously(argus_incidents: IncidentMap, zino_cases: CaseMap):
+def synchronize_continuously(
+    argus_incidents: IncidentMap, zino_cases: CaseMap, instance: InstanceState
+):
     """Continuously "poll" the Zino notification channel and update Argus accordingly"""
     global _last_incident_refresh
     while True:
-        if datetime.now() > (_last_incident_refresh + INCIDENT_REFRESH_INTERVAL):
-            # Refreshes Argus incidents at least every INCIDENT_REFRESH_INTERVAL
-            refresh_argus_incidents(argus_incidents, zino_cases)
-            _last_incident_refresh = datetime.now()
+        instance.ping()
+
+        if instance.is_active:
+            if datetime.now() > (_last_incident_refresh + INCIDENT_REFRESH_INTERVAL):
+                refresh_argus_incidents(argus_incidents, zino_cases)
+                _last_incident_refresh = datetime.now()
 
         update = _notifier.poll(timeout=POLL_TIMEOUT)
         if not update:
@@ -283,6 +296,9 @@ def synchronize_continuously(argus_incidents: IncidentMap, zino_cases: CaseMap):
 
         if not is_case_interesting(case):
             # Ignore this update, as it's not interesting to us
+            continue
+
+        if not instance.is_active:
             continue
 
         incident = get_or_make_argus_incident_for_zino_case(

--- a/src/zinoargus/__init__.py
+++ b/src/zinoargus/__init__.py
@@ -50,8 +50,9 @@ _logger = logging.getLogger("zinoargus")
 FORMATTER = logging.Formatter("%(asctime)s - %(name)s - %(levelname)s - %(message)s")
 HISTORY_EVENT_TYPE = "OTH"  # Other
 INCIDENT_ATTRIBUTE_CHANGE_TYPE = "CHI"
-POLL_TIMEOUT = 30  # seconds
-INCIDENT_REFRESH_INTERVAL = timedelta(seconds=POLL_TIMEOUT)
+POLL_TIMEOUT = 5  # seconds
+PING_INTERVAL = timedelta(seconds=5)
+INCIDENT_REFRESH_INTERVAL = timedelta(seconds=30)
 MY_TZINFO = datetime.now().astimezone().tzinfo
 
 _config: Optional[Configuration] = None
@@ -60,6 +61,7 @@ _notifier: Optional[ritz.notifier] = None
 _argus: Optional[Client] = None
 _circuit_metadata = dict()
 _last_incident_refresh = datetime.now()
+_last_ping = datetime.now()
 
 
 def main():
@@ -264,8 +266,11 @@ def synchronize_continuously(
 ):
     """Continuously "poll" the Zino notification channel and update Argus accordingly"""
     global _last_incident_refresh
+    global _last_ping
     while True:
-        instance.ping()
+        if datetime.now() > (_last_ping + PING_INTERVAL):
+            instance.ping()
+            _last_ping = datetime.now()
 
         if instance.is_active:
             if datetime.now() > (_last_incident_refresh + INCIDENT_REFRESH_INTERVAL):

--- a/src/zinoargus/config/models.py
+++ b/src/zinoargus/config/models.py
@@ -82,6 +82,18 @@ class SyncConfiguration(BaseModel):
     ticket: Optional[TicketSyncConfiguration] = TicketSyncConfiguration()
 
 
+class FailoverConfiguration(BaseModel):
+    """Configuration for primary/secondary failover mode"""
+
+    model_config = ConfigDict(extra="forbid")
+
+    primary_server: Host
+    primary_snmp_port: int = 8000
+    snmp_community: str = "public"
+    ping_timeout: int = 5
+    threshold: int = 10
+
+
 class Configuration(BaseModel):
     """Class for modeling the Zino-Argus glue service configuration"""
 
@@ -92,3 +104,4 @@ class Configuration(BaseModel):
     zino: ZinoConfiguration
     sync: Optional[SyncConfiguration] = SyncConfiguration()
     metadata: Optional[MetadataConfiguration] = MetadataConfiguration()
+    failover: Optional[FailoverConfiguration] = None

--- a/src/zinoargus/failover.py
+++ b/src/zinoargus/failover.py
@@ -1,0 +1,94 @@
+"""Failover state machine for primary/secondary Zino deployments."""
+
+import logging
+from enum import Enum
+
+from zinoargus.zping import ZpingError, get_zino_uptime
+
+_logger = logging.getLogger(__name__)
+
+
+class Mode(Enum):
+    STANDBY = "standby"
+    ACTIVE = "active"
+
+
+class InstanceState:
+    """Tracks whether this instance should actively sync to Argus.
+
+    When no failover configuration is provided, the instance is always ACTIVE
+    (primary mode). When configured, starts in STANDBY and switches to ACTIVE
+    after ``threshold`` consecutive ping failures to the primary, then back to
+    STANDBY after ``threshold`` consecutive successes.
+    """
+
+    def __init__(self, config=None):
+        self._config = config
+        if config is None:
+            self._mode = Mode.ACTIVE
+        else:
+            self._mode = Mode.STANDBY
+        self._consecutive_failures = 0
+        self._consecutive_successes = 0
+
+    @property
+    def mode(self) -> Mode:
+        return self._mode
+
+    @property
+    def is_active(self) -> bool:
+        return self._mode is Mode.ACTIVE
+
+    def ping(self) -> None:
+        """Ping the primary Zino and update failover state.
+
+        No-op when running in primary mode (no failover config).
+        """
+        if self._config is None:
+            return
+
+        try:
+            get_zino_uptime(
+                host=str(self._config.primary_server),
+                port=self._config.primary_snmp_port,
+                community=self._config.snmp_community,
+                timeout=self._config.ping_timeout,
+            )
+        except ZpingError:
+            self._on_failure()
+        else:
+            self._on_success()
+
+    def _on_success(self) -> None:
+        self._consecutive_successes += 1
+        self._consecutive_failures = 0
+
+        if (
+            self._mode is Mode.ACTIVE
+            and self._consecutive_successes >= self._config.threshold
+        ):
+            _logger.info(
+                "Primary is back (%s consecutive successes), switching to STANDBY",
+                self._consecutive_successes,
+            )
+            self._mode = Mode.STANDBY
+            self._reset_counters()
+
+    def _on_failure(self) -> None:
+        self._consecutive_failures += 1
+        self._consecutive_successes = 0
+
+        if (
+            self._mode is Mode.STANDBY
+            and self._consecutive_failures >= self._config.threshold
+        ):
+            _logger.warning(
+                "Primary unreachable (%s consecutive failures), switching to ACTIVE",
+                self._consecutive_failures,
+            )
+            self._mode = Mode.ACTIVE
+            self._reset_counters()
+
+    def _reset_counters(self) -> None:
+        self._consecutive_failures = 0
+        self._consecutive_successes = 0

--- a/src/zinoargus/failover.py
+++ b/src/zinoargus/failover.py
@@ -48,16 +48,28 @@ class InstanceState:
             return
 
         try:
-            get_zino_uptime(
+            uptime = get_zino_uptime(
                 host=str(self._config.primary_server),
                 port=self._config.primary_snmp_port,
                 community=self._config.snmp_community,
                 timeout=self._config.ping_timeout,
             )
-        except ZpingError:
+        except ZpingError as exc:
             self._on_failure()
+            _logger.warning(
+                "Zino primary ping failed for %s: %s (%s consecutive)",
+                self._config.primary_server,
+                exc,
+                self._consecutive_failures,
+            )
         else:
             self._on_success()
+            _logger.debug(
+                "Zino primary ping OK for %s, uptime: %s (%s consecutive)",
+                self._config.primary_server,
+                uptime,
+                self._consecutive_successes,
+            )
 
     def _on_success(self) -> None:
         self._consecutive_successes += 1

--- a/src/zinoargus/zping.py
+++ b/src/zinoargus/zping.py
@@ -1,0 +1,69 @@
+"""Synchronous SNMP query to check if a Zino daemon is alive."""
+
+import asyncio
+
+from pysnmp.hlapi.asyncio import (
+    CommunityData,
+    ContextData,
+    ObjectIdentity,
+    ObjectType,
+    SnmpEngine,
+    UdpTransportTarget,
+    getCmd,
+)
+
+# ZINO-MIB::zinoUpTime.0
+ZINO_UPTIME_OID = "1.3.6.1.4.1.2428.130.1.1.1.0"
+
+
+class ZpingError(Exception):
+    """Raised when a Zino uptime query fails."""
+
+
+def get_zino_uptime(
+    host: str = "127.0.0.1",
+    port: int = 8000,
+    community: str = "public",
+    timeout: int = 5,
+) -> int:
+    """Query a Zino SNMP agent for its uptime.
+
+    :param host: Hostname or IP address of the Zino agent
+    :param port: UDP port the Zino SNMP agent listens on
+    :param community: SNMP community string
+    :param timeout: Timeout in seconds for the SNMP request
+    :return: Uptime in seconds
+    :raises ZpingError: When the agent is unreachable or returns an error
+    """
+    return asyncio.run(_get_zino_uptime(host, port, community, timeout))
+
+
+async def _get_zino_uptime(host: str, port: int, community: str, timeout: int) -> int:
+    snmp_engine = SnmpEngine()
+
+    try:
+        error_indication, error_status, error_index, var_binds = await getCmd(
+            snmp_engine,
+            CommunityData(community),
+            UdpTransportTarget((host, port), timeout=timeout, retries=0),
+            ContextData(),
+            ObjectType(ObjectIdentity(ZINO_UPTIME_OID)),
+        )
+    except Exception as exc:
+        snmp_engine.closeDispatcher()
+        raise ZpingError(f"SNMP request failed: {exc}") from exc
+
+    snmp_engine.closeDispatcher()
+
+    if error_indication:
+        raise ZpingError(str(error_indication))
+    if error_status:
+        raise ZpingError(
+            f"SNMP error: {error_status.prettyPrint()} at "
+            f"{var_binds[int(error_index) - 1][0] if error_index else '?'}"
+        )
+    if not var_binds:
+        raise ZpingError("Empty response from agent")
+
+    _, value = var_binds[0]
+    return int(value)

--- a/tests/config/test_config.py
+++ b/tests/config/test_config.py
@@ -30,6 +30,47 @@ def test_when_configuration_file_has_invalid_value_it_should_raise_invalid_confi
         read_configuration(invalid_value_configuration_file)
 
 
+class TestReadConfigurationWithFailover:
+    def test_when_failover_section_present_it_should_parse_correctly(
+        self, failover_configuration_file
+    ):
+        config = read_configuration(failover_configuration_file)
+        assert config.failover is not None
+        assert str(config.failover.primary_server) == "10.0.0.1"
+        assert config.failover.primary_snmp_port == 8000
+        assert config.failover.threshold == 5
+
+    def test_when_failover_section_absent_it_should_be_none(
+        self, valid_configuration_file
+    ):
+        config = read_configuration(valid_configuration_file)
+        assert config.failover is None
+
+
+@pytest.fixture
+def failover_configuration_file(tmp_path):
+    name = tmp_path / "zinoargus.toml"
+    with open(name, "w") as conf:
+        conf.write(
+            """[argus]
+            url = "https://argus.example.org/api/v2"
+            token = "secret"
+
+            [zino]
+            server = "zino.example.org"
+            port = 8001
+            user = "zinouser"
+            secret = "secret"
+
+            [failover]
+            primary_server = "10.0.0.1"
+            primary_snmp_port = 8000
+            threshold = 5
+            """
+        )
+    yield name
+
+
 @pytest.fixture
 def valid_configuration_file(tmp_path):
     name = tmp_path / "zinoargus.toml"

--- a/tests/config/test_models.py
+++ b/tests/config/test_models.py
@@ -1,9 +1,40 @@
 import pydantic
 import pytest
 
-from zinoargus.config.models import Configuration
+from zinoargus.config.models import Configuration, FailoverConfiguration
 
 
 def test_when_configuration_is_empty_it_should_not_validate():
     with pytest.raises(pydantic.ValidationError):
         Configuration()
+
+
+class TestFailoverConfiguration:
+    def test_when_only_primary_server_given_it_should_validate(self):
+        config = FailoverConfiguration(primary_server="10.0.0.1")
+        assert str(config.primary_server) == "10.0.0.1"
+        assert config.primary_snmp_port == 8000
+        assert config.snmp_community == "public"
+        assert config.ping_timeout == 5
+        assert config.threshold == 10
+
+    def test_when_primary_server_missing_it_should_not_validate(self):
+        with pytest.raises(pydantic.ValidationError):
+            FailoverConfiguration()
+
+    def test_when_extra_field_given_it_should_not_validate(self):
+        with pytest.raises(pydantic.ValidationError):
+            FailoverConfiguration(primary_server="10.0.0.1", bogus="value")
+
+
+class TestConfigurationFailover:
+    def test_when_failover_absent_it_should_be_none(self):
+        config = Configuration(
+            argus={"url": "https://argus.example.org/api/v2", "token": "secret"},
+            zino={
+                "server": "zino.example.org",
+                "user": "zinouser",
+                "secret": "secret",
+            },
+        )
+        assert config.failover is None

--- a/tests/test_failover.py
+++ b/tests/test_failover.py
@@ -59,6 +59,7 @@ class TestInstanceStateStandbyToActive:
             state.ping()
 
         assert not state.is_active
+        assert state.mode is Mode.STANDBY
 
     @patch("zinoargus.failover.get_zino_uptime")
     def test_when_success_interrupts_failures_it_should_reset_counter(
@@ -80,6 +81,7 @@ class TestInstanceStateStandbyToActive:
         state.ping()  # fail 2 again
 
         assert not state.is_active
+        assert state.mode is Mode.STANDBY
 
 
 class TestInstanceStateActiveToStandby:
@@ -156,3 +158,29 @@ class TestInstanceStateCounterResetOnTransition:
         state.ping()
         state.ping()
         assert state.is_active  # only 2 successes, counter was reset
+
+    @patch("zinoargus.failover.get_zino_uptime")
+    def test_when_transitioning_to_standby_counters_should_reset(self, mock_uptime):
+        mock_uptime.side_effect = ZpingError("unreachable")
+        config = _make_config(threshold=3)
+        state = InstanceState(config)
+
+        # Transition to ACTIVE
+        for _ in range(3):
+            state.ping()
+        assert state.is_active
+
+        # Transition back to STANDBY
+        mock_uptime.side_effect = None
+        mock_uptime.return_value = 100
+        for _ in range(3):
+            state.ping()
+        assert not state.is_active
+
+        # Counters reset, so one more success should NOT trigger anything weird
+        state.ping()
+        # Need full threshold of failures to go back to ACTIVE
+        mock_uptime.side_effect = ZpingError("unreachable")
+        state.ping()
+        state.ping()
+        assert not state.is_active  # only 2 failures, counter was reset

--- a/tests/test_failover.py
+++ b/tests/test_failover.py
@@ -1,0 +1,158 @@
+from unittest.mock import MagicMock, patch
+
+from zinoargus.failover import InstanceState, Mode
+from zinoargus.zping import ZpingError
+
+
+def _make_config(threshold=3):
+    config = MagicMock()
+    config.primary_server = "10.0.0.1"
+    config.primary_snmp_port = 8000
+    config.snmp_community = "public"
+    config.ping_timeout = 5
+    config.threshold = threshold
+    return config
+
+
+class TestInstanceStateWithoutConfig:
+    def test_when_no_config_it_should_always_be_active(self):
+        state = InstanceState(None)
+        assert state.is_active
+        assert state.mode is Mode.ACTIVE
+
+    @patch("zinoargus.failover.get_zino_uptime")
+    def test_when_no_config_ping_should_be_noop(self, mock_uptime):
+        state = InstanceState(None)
+        state.ping()
+        mock_uptime.assert_not_called()
+        assert state.is_active
+
+
+class TestInstanceStateStandbyToActive:
+    @patch("zinoargus.failover.get_zino_uptime")
+    def test_when_configured_it_should_start_in_standby(self, mock_uptime):
+        state = InstanceState(_make_config())
+        assert not state.is_active
+        assert state.mode is Mode.STANDBY
+
+    @patch("zinoargus.failover.get_zino_uptime")
+    def test_when_threshold_failures_reached_it_should_switch_to_active(
+        self, mock_uptime
+    ):
+        mock_uptime.side_effect = ZpingError("unreachable")
+        state = InstanceState(_make_config(threshold=3))
+
+        for _ in range(3):
+            state.ping()
+
+        assert state.is_active
+        assert state.mode is Mode.ACTIVE
+
+    @patch("zinoargus.failover.get_zino_uptime")
+    def test_when_fewer_than_threshold_failures_it_should_stay_in_standby(
+        self, mock_uptime
+    ):
+        mock_uptime.side_effect = ZpingError("unreachable")
+        state = InstanceState(_make_config(threshold=3))
+
+        for _ in range(2):
+            state.ping()
+
+        assert not state.is_active
+
+    @patch("zinoargus.failover.get_zino_uptime")
+    def test_when_success_interrupts_failures_it_should_reset_counter(
+        self, mock_uptime
+    ):
+        config = _make_config(threshold=3)
+        state = InstanceState(config)
+
+        mock_uptime.side_effect = ZpingError("unreachable")
+        state.ping()  # fail 1
+        state.ping()  # fail 2
+
+        mock_uptime.side_effect = None
+        mock_uptime.return_value = 100
+        state.ping()  # success resets counter
+
+        mock_uptime.side_effect = ZpingError("unreachable")
+        state.ping()  # fail 1 again
+        state.ping()  # fail 2 again
+
+        assert not state.is_active
+
+
+class TestInstanceStateActiveToStandby:
+    @patch("zinoargus.failover.get_zino_uptime")
+    def test_when_threshold_successes_reached_it_should_switch_to_standby(
+        self, mock_uptime
+    ):
+        mock_uptime.side_effect = ZpingError("unreachable")
+        config = _make_config(threshold=3)
+        state = InstanceState(config)
+
+        # First get to ACTIVE
+        for _ in range(3):
+            state.ping()
+        assert state.is_active
+
+        # Now succeed threshold times
+        mock_uptime.side_effect = None
+        mock_uptime.return_value = 100
+        for _ in range(3):
+            state.ping()
+
+        assert not state.is_active
+        assert state.mode is Mode.STANDBY
+
+    @patch("zinoargus.failover.get_zino_uptime")
+    def test_when_failure_interrupts_successes_it_should_reset_counter(
+        self, mock_uptime
+    ):
+        mock_uptime.side_effect = ZpingError("unreachable")
+        config = _make_config(threshold=3)
+        state = InstanceState(config)
+
+        # Get to ACTIVE
+        for _ in range(3):
+            state.ping()
+        assert state.is_active
+
+        # Two successes then a failure
+        mock_uptime.side_effect = None
+        mock_uptime.return_value = 100
+        state.ping()
+        state.ping()
+
+        mock_uptime.side_effect = ZpingError("unreachable")
+        state.ping()  # resets success counter
+
+        mock_uptime.side_effect = None
+        mock_uptime.return_value = 100
+        state.ping()
+        state.ping()
+
+        # Still active (only 2 consecutive successes)
+        assert state.is_active
+
+
+class TestInstanceStateCounterResetOnTransition:
+    @patch("zinoargus.failover.get_zino_uptime")
+    def test_when_transitioning_to_active_counters_should_reset(self, mock_uptime):
+        mock_uptime.side_effect = ZpingError("unreachable")
+        config = _make_config(threshold=3)
+        state = InstanceState(config)
+
+        # Transition to ACTIVE
+        for _ in range(3):
+            state.ping()
+        assert state.is_active
+
+        # Counters reset, so one more failure should NOT trigger anything weird
+        state.ping()
+        # Need full threshold of successes to go back
+        mock_uptime.side_effect = None
+        mock_uptime.return_value = 100
+        state.ping()
+        state.ping()
+        assert state.is_active  # only 2 successes, counter was reset

--- a/tests/test_zping.py
+++ b/tests/test_zping.py
@@ -1,0 +1,55 @@
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from zinoargus.zping import ZpingError, get_zino_uptime
+
+PATCH_GET_CMD = "zinoargus.zping.getCmd"
+
+
+class TestGetZinoUptime:
+    @patch(PATCH_GET_CMD, new_callable=AsyncMock)
+    def test_when_agent_responds_it_should_return_uptime_as_int(self, mock_get_cmd):
+        mock_value = MagicMock()
+        mock_value.__int__ = lambda self: 42
+        mock_get_cmd.return_value = (None, None, None, [("oid", mock_value)])
+
+        result = get_zino_uptime()
+
+        assert result == 42
+
+    @patch(PATCH_GET_CMD, new_callable=AsyncMock)
+    def test_when_error_indication_it_should_raise_zping_error(self, mock_get_cmd):
+        mock_get_cmd.return_value = ("requestTimedOut", None, None, [])
+
+        with pytest.raises(ZpingError, match="requestTimedOut"):
+            get_zino_uptime()
+
+    @patch(PATCH_GET_CMD, new_callable=AsyncMock)
+    def test_when_error_status_it_should_raise_zping_error(self, mock_get_cmd):
+        mock_status = MagicMock()
+        mock_status.__bool__ = lambda self: True
+        mock_status.prettyPrint.return_value = "noSuchName"
+        mock_get_cmd.return_value = (
+            None,
+            mock_status,
+            1,
+            [("1.3.6.1", MagicMock())],
+        )
+
+        with pytest.raises(ZpingError, match="SNMP error"):
+            get_zino_uptime()
+
+    @patch(PATCH_GET_CMD, new_callable=AsyncMock)
+    def test_when_empty_response_it_should_raise_zping_error(self, mock_get_cmd):
+        mock_get_cmd.return_value = (None, None, None, [])
+
+        with pytest.raises(ZpingError, match="Empty response"):
+            get_zino_uptime()
+
+    @patch(PATCH_GET_CMD, new_callable=AsyncMock)
+    def test_when_exception_raised_it_should_raise_zping_error(self, mock_get_cmd):
+        mock_get_cmd.side_effect = RuntimeError("connection failed")
+
+        with pytest.raises(ZpingError, match="SNMP request failed"):
+            get_zino_uptime()

--- a/zinoargus.toml.example
+++ b/zinoargus.toml.example
@@ -30,3 +30,14 @@ ticket.enable = false
 [metadata]
 # Optional circuit metadata from telemator
 ports_url = "http://telemator.circuit.mapping.server/tm/curitz_circuitmapping.json"
+
+# Optional failover configuration for primary/secondary deployments.
+# When this section is absent, the daemon runs in primary mode (always
+# active).  When configured, the daemon starts in standby and monitors
+# the primary Zino via SNMP, taking over if it becomes unreachable.
+#[failover]
+#primary_server = "10.0.0.1"
+#primary_snmp_port = 8000
+#snmp_community = "public"
+#ping_timeout = 5
+#threshold = 10


### PR DESCRIPTION
Adds a failover mechanism where a secondary instance monitors the primary Zino via SNMP and only syncs to Argus when the primary is unreachable.

The secondary starts in STANDBY mode and switches to ACTIVE after a configurable number of consecutive ping failures, then back to STANDBY when the primary recovers. When no `[failover]` section is configured, the daemon runs in primary mode (always active) as before.

This is probably best reviewed commit-by-commit :)

Fixes #30.  Depends on #31 .