### PR TITLE
Add more Zino event data as Argus incident tags

### DIFF
--- a/changelog.d/33.added.1.md
+++ b/changelog.d/33.added.1.md
@@ -1,0 +1,1 @@
+A new optional `default_domain` setting in the `[zino]` config section qualifies bare router names into FQDNs for the `host` tag.

--- a/changelog.d/33.added.md
+++ b/changelog.d/33.added.md
@@ -1,0 +1,1 @@
+Argus incidents now carry `event_type` and `priority` tags for every Zino case, plus `remote_as` and `remote_addr` tags for BGP cases.

--- a/src/zinoargus/__init__.py
+++ b/src/zinoargus/__init__.py
@@ -21,7 +21,7 @@ import sys
 import time
 from datetime import datetime, timedelta, timezone
 from operator import itemgetter
-from typing import Optional
+from typing import Iterator, Optional
 
 import requests
 import zinolib as ritz
@@ -731,14 +731,35 @@ def describe_zino_case(zino_case: ritz.Case):
     return None
 
 
-def generate_tags(zino_case):
-    yield "host", zino_case.router
+def generate_tags(zino_case: ritz.Case) -> Iterator[tuple[str, str]]:
+    yield "host", _qualify_host(zino_case.router)
+    yield "event_type", zino_case.type.value
+    yield "priority", str(zino_case.priority)
     if zino_case.type == ritz.caseType.PORTSTATE:
         yield "interface", zino_case.port
         descr = zino_case.get("descr")
         if descr:
             yield "description", descr
-            # GET UN
+    elif zino_case.type == ritz.caseType.BGP:
+        remote_as = zino_case.get("remote_as")
+        if remote_as is not None:
+            yield "remote_as", str(remote_as)
+        remote_addr = zino_case.get("remote_addr")
+        if remote_addr is not None:
+            yield "remote_addr", str(remote_addr)
+
+
+def _qualify_host(router: str) -> str:
+    """Return the router name as an FQDN using the configured default domain.
+
+    The domain is only appended to bare router names; a name that already
+    contains a dot is assumed to be fully qualified and returned unchanged.
+    This assumes router names are hostnames, not IP literals.
+    """
+    domain = _config.zino.default_domain
+    if domain and "." not in router:
+        return f"{router}.{domain}"
+    return router
 
 
 def close_argus_incident(

--- a/src/zinoargus/config/models.py
+++ b/src/zinoargus/config/models.py
@@ -50,6 +50,7 @@ class ZinoConfiguration(BaseModel):
     port: int = 8001
     user: str
     secret: str
+    default_domain: Optional[str] = None
 
 
 class MetadataConfiguration(BaseModel):

--- a/tests/config/test_models.py
+++ b/tests/config/test_models.py
@@ -5,6 +5,7 @@ from zinoargus.config.models import (
     Configuration,
     FailoverConfiguration,
     SeverityConfiguration,
+    ZinoConfiguration,
 )
 
 
@@ -29,6 +30,24 @@ class TestFailoverConfiguration:
     def test_when_extra_field_given_it_should_not_validate(self):
         with pytest.raises(pydantic.ValidationError):
             FailoverConfiguration(primary_server="10.0.0.1", bogus="value")
+
+
+class TestZinoConfiguration:
+    def _minimal_kwargs(self, **extra):
+        return {
+            "server": "zino.example.org",
+            "user": "zinouser",
+            "secret": "secret",
+            **extra,
+        }
+
+    def test_when_given_a_value_then_default_domain_should_be_retained(self):
+        config = ZinoConfiguration(**self._minimal_kwargs(default_domain="example.org"))
+        assert config.default_domain == "example.org"
+
+    def test_when_omitted_then_default_domain_should_default_to_none(self):
+        config = ZinoConfiguration(**self._minimal_kwargs())
+        assert config.default_domain is None
 
 
 class TestConfigurationFailover:

--- a/tests/test_tags.py
+++ b/tests/test_tags.py
@@ -1,0 +1,116 @@
+from types import SimpleNamespace
+
+import pytest
+
+import zinoargus
+from zinoargus import generate_tags
+
+
+class FakeCase:
+    """Minimal stand-in for a ritz.Case exposing the bits generate_tags uses."""
+
+    def __init__(self, type, router="rtr1", priority=100, **attrs):
+        self.type = type
+        self.router = router
+        self.priority = priority
+        self._attrs = attrs
+
+    def __getattr__(self, name):
+        return self._attrs[name]
+
+    def get(self, key, default=None):
+        return self._attrs.get(key, default)
+
+
+class TestGenerateTags:
+    def test_when_any_case_then_it_should_always_tag_event_type_and_priority(
+        self, no_domain_config
+    ):
+        case = FakeCase(zinoargus.ritz.caseType.REACHABILITY, priority=200)
+        tags = dict(generate_tags(case))
+        assert tags["event_type"] == "reachability"
+        assert tags["priority"] == "200"
+        assert tags["host"] == "rtr1"
+
+    def test_when_portstate_case_then_it_should_tag_interface_and_description(
+        self, no_domain_config
+    ):
+        case = FakeCase(
+            zinoargus.ritz.caseType.PORTSTATE,
+            port="GigabitEthernet0/1",
+            descr="uplink, to core",
+        )
+        tags = dict(generate_tags(case))
+        assert tags["interface"] == "GigabitEthernet0/1"
+        assert tags["description"] == "uplink, to core"
+
+    def test_when_portstate_case_without_descr_then_it_should_omit_description(
+        self, no_domain_config
+    ):
+        case = FakeCase(zinoargus.ritz.caseType.PORTSTATE, port="ge-0/0/0")
+        tags = dict(generate_tags(case))
+        assert "description" not in tags
+
+    def test_when_bgp_case_then_it_should_tag_remote_as_and_remote_addr(
+        self, no_domain_config
+    ):
+        case = FakeCase(
+            zinoargus.ritz.caseType.BGP, remote_as=64512, remote_addr="192.0.2.1"
+        )
+        tags = dict(generate_tags(case))
+        assert tags["remote_as"] == "64512"
+        assert tags["remote_addr"] == "192.0.2.1"
+
+    def test_when_bgp_case_without_peer_attrs_then_it_should_omit_them(
+        self, no_domain_config
+    ):
+        case = FakeCase(zinoargus.ritz.caseType.BGP)
+        tags = dict(generate_tags(case))
+        assert "remote_as" not in tags
+        assert "remote_addr" not in tags
+
+    def test_when_default_domain_set_then_it_should_qualify_the_host_tag(
+        self, monkeypatch
+    ):
+        _domain_config(monkeypatch, "example.org")
+        case = FakeCase(zinoargus.ritz.caseType.REACHABILITY, router="rtr1")
+        tags = dict(generate_tags(case))
+        assert tags["host"] == "rtr1.example.org"
+
+
+class TestQualifyHost:
+    def test_when_domain_set_and_name_bare_then_it_should_append_domain(
+        self, monkeypatch
+    ):
+        _domain_config(monkeypatch, "example.org")
+        assert zinoargus._qualify_host("rtr1") == "rtr1.example.org"
+
+    def test_when_name_already_qualified_then_it_should_return_unchanged(
+        self, monkeypatch
+    ):
+        _domain_config(monkeypatch, "example.org")
+        assert zinoargus._qualify_host("rtr1.other.net") == "rtr1.other.net"
+
+    def test_when_domain_unset_then_it_should_return_unchanged(self, no_domain_config):
+        assert zinoargus._qualify_host("rtr1") == "rtr1"
+
+    def test_when_domain_is_empty_string_then_it_should_return_unchanged(
+        self, monkeypatch
+    ):
+        _domain_config(monkeypatch, "")
+        assert zinoargus._qualify_host("rtr1") == "rtr1"
+
+
+@pytest.fixture
+def no_domain_config(monkeypatch):
+    monkeypatch.setattr(
+        zinoargus, "_config", SimpleNamespace(zino=SimpleNamespace(default_domain=None))
+    )
+
+
+def _domain_config(monkeypatch, domain):
+    monkeypatch.setattr(
+        zinoargus,
+        "_config",
+        SimpleNamespace(zino=SimpleNamespace(default_domain=domain)),
+    )

--- a/zinoargus.toml.example
+++ b/zinoargus.toml.example
@@ -15,6 +15,11 @@ port = 8001
 user = "zinouser"
 secret = "1234123412341234123412341324123413241"
 
+# Optional domain used to build the Argus `host` tag as an FQDN. When set,
+# router names without a dot get this domain appended (e.g. "rtr1" ->
+# "rtr1.example.org").  Names that already contain a dot are left unchanged.
+#default_domain = "example.org"
+
 # Synchronization behavior options
 [sync]
 #  Argus incident acknowledgments can be synchronized back to Zino.  The


### PR DESCRIPTION
Until now the glue tagged each Argus incident only with `host`, plus `interface`/`description` for port-state cases. That left operators unable to filter or route incidents in Argus by the kind of Zino event, by Zino's own priority, or by BGP peer — all of which Zino already knows.

This adds `event_type` and `priority` tags to every incident, and `remote_as`/`remote_addr` tags to BGP incidents, in [`generate_tags()`](https://github.com/Uninett/zino-argus-glue/blob/c366e0165f430a77a842c24c047e8776d7124987/src/zinoargus/__init__.py#L734).

It also makes the `host` tag FQDN-capable. By convention the Argus `host` tag *is* the FQDN, but Zino normally reports bare router names, and the per-router domain is a server-side `polldevs.cf` attribute that Zino never exposes to API clients (confirmed against both Zino 1 and Zino 2). Rather than reverse-DNS, this introduces an optional [`[zino].default_domain`](https://github.com/Uninett/zino-argus-glue/blob/c366e0165f430a77a842c24c047e8776d7124987/src/zinoargus/config/models.py#L53) setting; [`_qualify_host()`](https://github.com/Uninett/zino-argus-glue/blob/c366e0165f430a77a842c24c047e8776d7124987/src/zinoargus/__init__.py#L752) appends it to router names that have no dot, leaving already-qualified names untouched.

Tags remain write-once (set when the incident is created); existing tagging behaviour is otherwise unchanged.
