### PR TITLE
Survive transient Zino and Argus failures instead of crashing

### DIFF
--- a/changelog.d/+robustness.fixed.md
+++ b/changelog.d/+robustness.fixed.md
@@ -1,0 +1,1 @@
+Made the daemon resilient to transient faults instead of exiting on the first error. It now reconnects to Zino with exponential backoff after a dropped connection and retries intermittent Argus REST errors (5xx/network) in place. Authentication failures on either side remain fatal.

--- a/src/zinoargus/__init__.py
+++ b/src/zinoargus/__init__.py
@@ -18,6 +18,7 @@ import argparse
 import logging
 import signal
 import sys
+import time
 from datetime import datetime, timedelta, timezone
 from operator import itemgetter
 from typing import Optional
@@ -26,7 +27,11 @@ import requests
 import zinolib as ritz
 from pyargus.client import Client
 from pyargus.models import Event, Incident
-from simple_rest_client.exceptions import ClientConnectionError
+from simple_rest_client.exceptions import (
+    AuthError,
+    ClientConnectionError,
+    ServerError,
+)
 from zinolib.ritz import NotifierResponse
 
 from zinoargus.config import (
@@ -55,6 +60,14 @@ PING_INTERVAL = timedelta(seconds=5)
 INCIDENT_REFRESH_INTERVAL = timedelta(seconds=30)
 MY_TZINFO = datetime.now().astimezone().tzinfo
 
+# Exponential backoff for reconnecting to Zino after a dropped/failed connection
+RECONNECT_BACKOFF_BASE = timedelta(seconds=5)
+RECONNECT_BACKOFF_MAX = timedelta(seconds=300)
+RECONNECT_BACKOFF_FACTOR = 2
+# A connection that stayed up at least this long is considered healthy, so the
+# backoff delay is reset to the base value before the next reconnect attempt.
+RECONNECT_RESET_AFTER = timedelta(seconds=60)
+
 _config: Optional[Configuration] = None
 _zino: Optional[ritz.ritz] = None
 _notifier: Optional[ritz.notifier] = None
@@ -65,8 +78,6 @@ _last_ping = datetime.now()
 
 
 def main():
-    global _zino
-    global _notifier
     global _argus
     global _config
 
@@ -91,37 +102,72 @@ def main():
 
     _argus = get_argus_client(_config.argus)
 
-    """Initiate connectionloop to Zino"""
-    try:
-        _zino, _notifier = connect_to_zino(_config.zino)
-        start()
+    run_supervised()
 
-        # TODO: If the Zino connection errors out, this should try to reconnect rather than die
-    except ritz.AuthenticationError:
-        _logger.critical("Unable to authenticate against Zino, retrying in 30sec")
-    except ritz.NotConnectedError:
-        _logger.critical("Lost connection with Zino, retrying in 30sec")
-    except ConnectionRefusedError:
-        _logger.critical(
-            "Connection refused by Zino (%s:%s)", _config.zino.server, _config.zino.port
-        )
-    except ClientConnectionError:
-        _logger.critical("Connection refused by Argus (%s)", _config.argus.url)
-    except KeyboardInterrupt:
-        _logger.critical("CTRL+C detected, exiting application")
-    except SystemExit:
-        _logger.critical("Received sigterm, exiting")
-    except Exception:  # pylint: disable=broad-except
-        # Break on an unhandled exception
-        _logger.critical("Unhandled exception from main event loop", exc_info=True)
-    finally:
+
+def run_supervised():
+    """Supervise the Zino connection and event loop, reconnecting after transient
+    failures with exponential backoff.
+
+    The Zino protocol is stateful, so any lost connection or protocol error requires
+    a full reconnect and re-sync.  Fatal conditions (bad credentials on either side)
+    cannot be recovered by retrying, so they terminate the daemon.
+    """
+    global _zino
+    global _notifier
+
+    delay = RECONNECT_BACKOFF_BASE
+    while True:
+        connected_at = None
         try:
-            _zino.close()
-        except Exception:  # noqa
-            pass
+            _zino, _notifier = connect_to_zino(_config.zino)
+            # Monotonic clock: measuring session duration must be immune to wall
+            # clock adjustments (NTP steps, DST).
+            connected_at = time.monotonic()
+            start()
+        except (ritz.AuthenticationError, AuthError) as error:
+            # Bad credentials/token won't fix themselves by retrying
+            _logger.critical("Fatal authentication error, exiting: %s", error)
+            break
+        except (KeyboardInterrupt, SystemExit):
+            _logger.info("Shutdown requested, exiting")
+            break
+        except (
+            ritz.NotConnectedError,
+            ritz.ProtocolError,
+            ConnectionError,
+            TimeoutError,
+            # Backstop for Argus errors raised outside a boundary guard (e.g. the
+            # unguarded calls during the initial full sync). Steady-state Argus
+            # errors are handled in place and never reach here.
+            ClientConnectionError,
+            ServerError,
+        ) as error:
+            _logger.error("Lost connection (%s), reconnecting", error)
+        except Exception:  # pylint: disable=broad-except
+            _logger.critical(
+                "Unhandled exception from main event loop, reconnecting",
+                exc_info=True,
+            )
+        finally:
+            try:
+                _zino.close()
+            except Exception:  # noqa
+                pass
+            _zino = None
+            _notifier = None
 
-        _zino = None
-        _notifier = None
+        # A connection that stayed up long enough is treated as healthy, so the
+        # next blip starts backing off from scratch rather than from a grown delay.
+        if (
+            connected_at is not None
+            and time.monotonic() - connected_at > RECONNECT_RESET_AFTER.total_seconds()
+        ):
+            delay = RECONNECT_BACKOFF_BASE
+
+        _logger.info("Reconnecting in %s seconds", delay.total_seconds())
+        time.sleep(delay.total_seconds())
+        delay = min(delay * RECONNECT_BACKOFF_FACTOR, RECONNECT_BACKOFF_MAX)
 
 
 def connect_to_zino(

--- a/src/zinoargus/__init__.py
+++ b/src/zinoargus/__init__.py
@@ -68,6 +68,17 @@ RECONNECT_BACKOFF_FACTOR = 2
 # backoff delay is reset to the base value before the next reconnect attempt.
 RECONNECT_RESET_AFTER = timedelta(seconds=60)
 
+# Bounded retries for individual Argus REST operations.  Argus is a stateless REST
+# API, so transient errors (5xx, network blips) are retried in place rather than
+# tearing down the whole event loop.
+ARGUS_RETRY_ATTEMPTS = 3
+ARGUS_RETRY_BASE = timedelta(seconds=1)
+ARGUS_RETRY_MAX = timedelta(seconds=10)
+ARGUS_RETRY_FACTOR = 2
+# Argus errors worth retrying: server-side (5xx) and network/connection failures.
+# Other client errors (4xx) are not retried — a 404/400 won't fix itself.
+RETRYABLE_ARGUS_ERRORS = (ServerError, ClientConnectionError)
+
 _config: Optional[Configuration] = None
 _zino: Optional[ritz.ritz] = None
 _notifier: Optional[ritz.notifier] = None
@@ -194,6 +205,45 @@ def get_argus_client(configuration: ArgusConfiguration) -> Client:
     )
 
 
+def call_argus(operation, *args, **kwargs):
+    """Invoke an Argus client operation, retrying transient errors with bounded
+    exponential backoff.
+
+    Server (5xx) and network errors are retried up to ``ARGUS_RETRY_ATTEMPTS`` times;
+    the last error is re-raised on exhaustion so the caller's boundary guard can log
+    and skip the operation.  ``AuthError`` is never retried (a bad token won't fix
+    itself) and propagates to the supervisor, which exits.
+    """
+    delay = ARGUS_RETRY_BASE
+    for attempt in range(1, ARGUS_RETRY_ATTEMPTS + 1):
+        try:
+            return operation(*args, **kwargs)
+        except AuthError:
+            raise
+        except RETRYABLE_ARGUS_ERRORS as error:
+            if attempt == ARGUS_RETRY_ATTEMPTS:
+                _logger.error(
+                    "Argus operation %s failed after %s attempts: %s",
+                    getattr(operation, "__name__", operation),
+                    attempt,
+                    error,
+                )
+                raise
+            _logger.warning(
+                "Argus operation %s failed (%s), retry %s/%s in %s seconds",
+                getattr(operation, "__name__", operation),
+                error,
+                attempt,
+                ARGUS_RETRY_ATTEMPTS,
+                delay.total_seconds(),
+            )
+            time.sleep(delay.total_seconds())
+            delay = min(delay * ARGUS_RETRY_FACTOR, ARGUS_RETRY_MAX)
+    # The loop always returns or re-raises; this guards against a future edit
+    # introducing a path that falls through and silently returns None.
+    raise RuntimeError("call_argus exhausted its loop without returning")
+
+
 def start():
     """This is the main "event loop" of the Zino-Argus glue service, called when there
     are successful connections to the Zino and Argus API, and torn down when the
@@ -232,7 +282,7 @@ def get_all_my_argus_incidents() -> IncidentMap:
     this glue service instance.
     """
     argus_incidents: IncidentMap = {}
-    for incident in _argus.get_my_incidents(open=True):
+    for incident in call_argus(lambda: list(_argus.get_my_incidents(open=True))):
         if not incident.source_incident_id:
             _logger.error(
                 "Ignoring incident %s with no 'source_incident_id' set (%r)",
@@ -372,7 +422,7 @@ def refresh_argus_incidents(argus_incidents: IncidentMap, zino_cases: CaseMap):
     do_update_on_ack = _config.sync.acknowledge.setstate != "none"
     _logger.info("Refreshing %s Argus incidents", len(argus_incidents))
     for case_id, old_incident in argus_incidents.items():
-        new_incident = _argus.get_incident(old_incident.pk)
+        new_incident = call_argus(_argus.get_incident, old_incident.pk)
         argus_incidents[case_id] = new_incident
 
         if do_update_on_ack and new_incident.acked and not old_incident.acked:
@@ -398,7 +448,7 @@ def update_case_acknowledged(incident: Incident, case: ritz.Case, desired_state:
 
     _logger.info(msg + ", setting Zino case to %r", incident.pk, case_id, desired_state)
 
-    acks = _argus.get_incident_acknowledgements(incident)
+    acks = call_argus(_argus.get_incident_acknowledgements, incident)
     acks.sort(key=lambda ack: ack.event.timestamp, reverse=True)
     _logger.debug("Argus incident %s acks: %r", incident.pk, acks)
 
@@ -440,7 +490,7 @@ def find_who_added_incident_ticket(incident: Incident, ticket_url: str) -> str:
     # timestamp (they seem to be by Argus 2.0, at least), so the first event we
     # find that contains the ticket URL should be the event that represents the change
     # to the current value.
-    for event in _argus.get_incident_events(incident):
+    for event in call_argus(_argus.get_incident_events, incident):
         if (
             event.type == INCIDENT_ATTRIBUTE_CHANGE_TYPE
             and ticket_url in event.description
@@ -461,7 +511,7 @@ def update_case_closed(incident: Incident, case: ritz.Case):
         incident.pk,
     )
 
-    events = _argus.get_incident_events(incident)
+    events = call_argus(_argus.get_incident_events, incident)
     events.sort(key=lambda event: event.timestamp, reverse=True)
     _logger.debug("Argus incident %s events: %r", incident.pk, events)
 
@@ -498,7 +548,7 @@ def synchronize_case_history(case: ritz.Case, incident: Incident):
     log entry with the user we have saved as our Zino username.
     """
     history = _zino.get_history(case.id)
-    existing_events = _argus.get_incident_events(incident)
+    existing_events = call_argus(_argus.get_incident_events, incident)
     # Filter out events that seem to originate from this glue service actor:
     my_actor = next(event.actor for event in existing_events if event.type == "STA")
     my_events_by_timestamp = {
@@ -547,8 +597,9 @@ def get_or_make_argus_incident_for_zino_case(
     if case_id in argus_incidents:
         return argus_incidents[case_id]
 
-    incidents = _argus.get_my_incidents(source_incident_id=case_id)
-    incident = next(incidents, None)
+    incident = call_argus(
+        lambda: next(_argus.get_my_incidents(source_incident_id=case_id), None)
+    )
     if incident:
         argus_incidents[case_id] = incident
         return incident

--- a/src/zinoargus/__init__.py
+++ b/src/zinoargus/__init__.py
@@ -30,6 +30,7 @@ from pyargus.models import Event, Incident
 from simple_rest_client.exceptions import (
     AuthError,
     ClientConnectionError,
+    ClientError,
     ServerError,
 )
 from zinolib.ritz import NotifierResponse
@@ -78,6 +79,11 @@ ARGUS_RETRY_FACTOR = 2
 # Argus errors worth retrying: server-side (5xx) and network/connection failures.
 # Other client errors (4xx) are not retried — a 404/400 won't fix itself.
 RETRYABLE_ARGUS_ERRORS = (ServerError, ClientConnectionError)
+# Argus errors a boundary guard should log and skip rather than let crash the
+# daemon: the retryable ones plus other client errors (e.g. an incident deleted
+# server-side returns 404).  AuthError is a ClientError subclass but is fatal, so
+# the guards re-raise it explicitly before falling back to this catch-all.
+SKIPPABLE_ARGUS_ERRORS = (ServerError, ClientConnectionError, ClientError)
 
 _config: Optional[Configuration] = None
 _zino: Optional[ritz.ritz] = None
@@ -402,15 +408,33 @@ def synchronize_continuously(
         if not instance.is_active:
             continue
 
-        incident = get_or_make_argus_incident_for_zino_case(
-            update.id, case, argus_incidents
-        )
+        # Zino reads/writes above this point are intentionally unguarded: a Zino
+        # connection error must propagate to the supervisor for a reconnect.  Only
+        # the Argus-side work below is shielded from transient REST errors.
+        try:
+            incident = get_or_make_argus_incident_for_zino_case(
+                update.id, case, argus_incidents
+            )
 
-        if update.type == "state":
-            update_state(update, case, incident, zino_cases, argus_incidents)
+            if update.type == "state":
+                update_state(update, case, incident, zino_cases, argus_incidents)
 
-        if update.type == "history":
-            synchronize_case_history(case, incident)
+            if update.type == "history":
+                synchronize_case_history(case, incident)
+        except AuthError:
+            # Fatal: propagate to the supervisor, which exits.
+            raise
+        except SKIPPABLE_ARGUS_ERRORS as error:
+            # Skip this update. State/history changes for an existing incident are
+            # reconciled by the next refresh cycle. A brand-new case whose incident
+            # creation failed here is only retried on its next Zino notification, or
+            # on the next full re-sync after a reconnect.
+            _logger.warning(
+                "Skipping update for Zino case %s, Argus error: %s",
+                update.id,
+                error,
+            )
+            continue
 
 
 def refresh_argus_incidents(argus_incidents: IncidentMap, zino_cases: CaseMap):
@@ -421,22 +445,35 @@ def refresh_argus_incidents(argus_incidents: IncidentMap, zino_cases: CaseMap):
     """
     do_update_on_ack = _config.sync.acknowledge.setstate != "none"
     _logger.info("Refreshing %s Argus incidents", len(argus_incidents))
-    for case_id, old_incident in argus_incidents.items():
-        new_incident = call_argus(_argus.get_incident, old_incident.pk)
-        argus_incidents[case_id] = new_incident
+    # Iterate over a snapshot: the loop body may mutate argus_incidents.
+    for case_id, old_incident in list(argus_incidents.items()):
+        try:
+            new_incident = call_argus(_argus.get_incident, old_incident.pk)
+            argus_incidents[case_id] = new_incident
 
-        if do_update_on_ack and new_incident.acked and not old_incident.acked:
-            update_case_acknowledged(
-                incident=new_incident,
-                case=zino_cases[case_id],
-                desired_state=_config.sync.acknowledge.setstate,
+            if do_update_on_ack and new_incident.acked and not old_incident.acked:
+                update_case_acknowledged(
+                    incident=new_incident,
+                    case=zino_cases[case_id],
+                    desired_state=_config.sync.acknowledge.setstate,
+                )
+
+            if _config.sync.ticket.enable:
+                update_case_ticket(incident=new_incident, case_id=case_id)
+
+            if not new_incident.open and old_incident.open:
+                update_case_closed(incident=new_incident, case=zino_cases[case_id])
+        except AuthError:
+            # Fatal: propagate to the supervisor, which exits.
+            raise
+        except SKIPPABLE_ARGUS_ERRORS as error:
+            # Skip just this incident; the next refresh cycle will retry it.
+            _logger.warning(
+                "Skipping refresh of Argus incident %s, Argus error: %s",
+                old_incident.pk,
+                error,
             )
-
-        if _config.sync.ticket.enable:
-            update_case_ticket(incident=new_incident, case_id=case_id)
-
-        if not new_incident.open and old_incident.open:
-            update_case_closed(incident=new_incident, case=zino_cases[case_id])
+            continue
 
 
 def update_case_acknowledged(incident: Incident, case: ritz.Case, desired_state: str):

--- a/tests/test_robustness.py
+++ b/tests/test_robustness.py
@@ -1,0 +1,111 @@
+"""Unit tests for the daemon's robustness machinery: the supervisor reconnect
+loop, the Argus retry helper, the per-operation boundary guards, and the
+best-effort circuit-metadata fetch.
+"""
+
+from datetime import timedelta
+from unittest.mock import MagicMock, patch
+
+import zinolib as ritz
+from simple_rest_client.exceptions import (
+    AuthError,
+    ServerError,
+)
+
+import zinoargus
+
+
+def _server_error(message="boom"):
+    return ServerError(message=message, response=MagicMock())
+
+
+def _auth_error(message="bad token"):
+    return AuthError(message=message, response=MagicMock())
+
+
+def _make_config():
+    """A config mock covering the attributes the refresh path reads."""
+    config = MagicMock()
+    config.sync.acknowledge.setstate = "none"
+    config.sync.ticket.enable = False
+    return config
+
+
+@patch("zinoargus.time.sleep")
+@patch("zinoargus.start")
+@patch("zinoargus.connect_to_zino")
+class TestRunSupervised:
+    def test_when_connect_fails_once_then_it_should_reconnect_and_continue(
+        self, connect, start, sleep, monkeypatch
+    ):
+        monkeypatch.setattr(zinoargus, "_config", _make_config())
+        connect.side_effect = [
+            ritz.NotConnectedError("down"),
+            (MagicMock(), MagicMock()),
+        ]
+        # The second, successful connection runs start(), which we make exit cleanly.
+        start.side_effect = SystemExit()
+
+        zinoargus.run_supervised()
+
+        assert connect.call_count == 2
+        start.assert_called_once()
+        sleep.assert_called()  # backed off between the failed and the retried connect
+
+    def test_when_zino_authentication_fails_then_it_should_exit_without_retry(
+        self, connect, start, sleep, monkeypatch
+    ):
+        monkeypatch.setattr(zinoargus, "_config", _make_config())
+        connect.side_effect = ritz.AuthenticationError("nope")
+
+        zinoargus.run_supervised()
+
+        connect.assert_called_once()
+        sleep.assert_not_called()
+
+    def test_when_argus_authentication_fails_then_it_should_exit_without_retry(
+        self, connect, start, sleep, monkeypatch
+    ):
+        monkeypatch.setattr(zinoargus, "_config", _make_config())
+        connect.return_value = (MagicMock(), MagicMock())
+        start.side_effect = _auth_error()
+
+        zinoargus.run_supervised()
+
+        start.assert_called_once()
+        sleep.assert_not_called()
+
+    def test_when_sessions_are_short_lived_then_it_should_grow_the_backoff(
+        self, connect, start, sleep, monkeypatch
+    ):
+        monkeypatch.setattr(zinoargus, "_config", _make_config())
+        # A reset threshold far in the future means no session counts as healthy.
+        monkeypatch.setattr(zinoargus, "RECONNECT_RESET_AFTER", timedelta(days=1))
+        connect.return_value = (MagicMock(), MagicMock())
+        start.side_effect = [_server_error(), _server_error(), SystemExit()]
+
+        zinoargus.run_supervised()
+
+        delays = [call.args[0] for call in sleep.call_args_list]
+        assert delays == [
+            zinoargus.RECONNECT_BACKOFF_BASE.total_seconds(),
+            (
+                zinoargus.RECONNECT_BACKOFF_BASE * zinoargus.RECONNECT_BACKOFF_FACTOR
+            ).total_seconds(),
+        ]
+
+    def test_when_session_was_healthy_then_it_should_reset_the_backoff(
+        self, connect, start, sleep, monkeypatch
+    ):
+        monkeypatch.setattr(zinoargus, "_config", _make_config())
+        # A negative threshold means every session counts as healthy, so the
+        # backoff resets to base before each reconnect.
+        monkeypatch.setattr(zinoargus, "RECONNECT_RESET_AFTER", timedelta(seconds=-1))
+        connect.return_value = (MagicMock(), MagicMock())
+        start.side_effect = [_server_error(), _server_error(), SystemExit()]
+
+        zinoargus.run_supervised()
+
+        base = zinoargus.RECONNECT_BACKOFF_BASE.total_seconds()
+        delays = [call.args[0] for call in sleep.call_args_list]
+        assert delays == [base, base]

--- a/tests/test_robustness.py
+++ b/tests/test_robustness.py
@@ -14,6 +14,7 @@ from simple_rest_client.exceptions import (
     NotFoundError,
     ServerError,
 )
+from zinolib.ritz import NotifierResponse
 
 import zinoargus
 
@@ -155,3 +156,121 @@ class TestRunSupervised:
         base = zinoargus.RECONNECT_BACKOFF_BASE.total_seconds()
         delays = [call.args[0] for call in sleep.call_args_list]
         assert delays == [base, base]
+
+
+class TestRefreshArgusIncidents:
+    def _incident(self, pk, **kwargs):
+        incident = MagicMock()
+        incident.pk = pk
+        incident.acked = kwargs.get("acked", False)
+        incident.open = kwargs.get("open", True)
+        return incident
+
+    @patch("zinoargus.time.sleep")
+    def test_when_one_incident_is_transiently_unavailable_then_it_should_skip_and_continue(
+        self, _sleep, monkeypatch
+    ):
+        monkeypatch.setattr(zinoargus, "_config", _make_config())
+        argus = MagicMock()
+
+        def get_incident(pk):
+            if pk == 1:
+                raise _server_error()
+            return self._incident(pk)
+
+        argus.get_incident.side_effect = get_incident
+        monkeypatch.setattr(zinoargus, "_argus", argus)
+
+        argus_incidents = {10: self._incident(1), 20: self._incident(2)}
+        zino_cases = {10: MagicMock(), 20: MagicMock()}
+
+        zinoargus.refresh_argus_incidents(argus_incidents, zino_cases)
+
+        # Case 10 (pk 1) is skipped, but case 20 (pk 2) is refreshed.
+        assert argus_incidents[10].pk == 1  # untouched original
+        assert argus_incidents[20].pk == 2  # replaced with the fetched incident
+
+    def test_when_an_incident_returns_not_found_then_it_should_skip_and_continue(
+        self, monkeypatch
+    ):
+        # A 404 (incident deleted server-side) must be skipped in place, not allowed
+        # to escape and trigger a Zino reconnect.
+        monkeypatch.setattr(zinoargus, "_config", _make_config())
+        argus = MagicMock()
+
+        def get_incident(pk):
+            if pk == 1:
+                raise _not_found_error()
+            return self._incident(pk)
+
+        argus.get_incident.side_effect = get_incident
+        monkeypatch.setattr(zinoargus, "_argus", argus)
+
+        argus_incidents = {10: self._incident(1), 20: self._incident(2)}
+        zino_cases = {10: MagicMock(), 20: MagicMock()}
+
+        zinoargus.refresh_argus_incidents(argus_incidents, zino_cases)
+
+        assert argus_incidents[10].pk == 1  # skipped, untouched
+        assert argus_incidents[20].pk == 2  # still refreshed
+
+    def test_when_an_incident_refresh_raises_auth_error_then_it_should_propagate(
+        self, monkeypatch
+    ):
+        monkeypatch.setattr(zinoargus, "_config", _make_config())
+        argus = MagicMock()
+        argus.get_incident.side_effect = _auth_error()
+        monkeypatch.setattr(zinoargus, "_argus", argus)
+
+        argus_incidents = {10: self._incident(1)}
+        zino_cases = {10: MagicMock()}
+
+        with pytest.raises(AuthError):
+            zinoargus.refresh_argus_incidents(argus_incidents, zino_cases)
+
+
+class TestSynchronizeContinuously:
+    """Exercises a single guarded iteration of the event loop.
+
+    The loop runs forever, so each test makes the *second* notifier poll raise
+    ``SystemExit`` to break out once the behaviour under test has occurred.
+    """
+
+    def _setup(self, monkeypatch, poll_side_effect):
+        monkeypatch.setattr(zinoargus, "_config", _make_config())
+        notifier = MagicMock()
+        notifier.poll.side_effect = poll_side_effect
+        monkeypatch.setattr(zinoargus, "_notifier", notifier)
+        monkeypatch.setattr(zinoargus, "_zino", MagicMock())
+        monkeypatch.setattr(zinoargus, "_argus", MagicMock())
+        instance = MagicMock()
+        instance.is_active = True
+        return instance
+
+    def test_when_argus_processing_raises_transient_error_then_the_loop_should_continue(
+        self, monkeypatch
+    ):
+        update = NotifierResponse(id=42, type="state", info="open down")
+        instance = self._setup(monkeypatch, [update, SystemExit()])
+        monkeypatch.setattr(zinoargus, "is_case_interesting", lambda case: True)
+        monkeypatch.setattr(
+            zinoargus,
+            "get_or_make_argus_incident_for_zino_case",
+            MagicMock(side_effect=_server_error()),
+        )
+
+        # Reaching the second poll (SystemExit) proves the transient error on the
+        # first update was swallowed and the loop kept going.
+        with pytest.raises(SystemExit):
+            zinoargus.synchronize_continuously({}, {}, instance)
+
+    def test_when_zino_connection_drops_then_the_error_should_propagate(
+        self, monkeypatch
+    ):
+        update = NotifierResponse(id=42, type="state", info="open down")
+        instance = self._setup(monkeypatch, [update])
+        # Fetching the case details hits Zino and must not be swallowed.
+        zinoargus._zino.case.side_effect = ritz.NotConnectedError("down")
+
+        with pytest.raises(ritz.NotConnectedError):
+            zinoargus.synchronize_continuously({}, {}, instance)

--- a/tests/test_robustness.py
+++ b/tests/test_robustness.py
@@ -6,9 +6,12 @@ best-effort circuit-metadata fetch.
 from datetime import timedelta
 from unittest.mock import MagicMock, patch
 
+import pytest
 import zinolib as ritz
 from simple_rest_client.exceptions import (
     AuthError,
+    ClientConnectionError,
+    NotFoundError,
     ServerError,
 )
 
@@ -23,12 +26,55 @@ def _auth_error(message="bad token"):
     return AuthError(message=message, response=MagicMock())
 
 
+def _not_found_error(message="gone"):
+    return NotFoundError(message=message, response=MagicMock())
+
+
 def _make_config():
     """A config mock covering the attributes the refresh path reads."""
     config = MagicMock()
     config.sync.acknowledge.setstate = "none"
     config.sync.ticket.enable = False
     return config
+
+
+@patch("zinoargus.time.sleep")
+class TestCallArgus:
+    def test_when_operation_succeeds_then_it_should_return_the_result(self, _sleep):
+        operation = MagicMock(return_value="result")
+        assert zinoargus.call_argus(operation, 1, kw=2) == "result"
+        operation.assert_called_once_with(1, kw=2)
+
+    def test_when_a_transient_error_clears_then_it_should_retry(self, _sleep):
+        operation = MagicMock(side_effect=[_server_error(), "result"])
+        assert zinoargus.call_argus(operation) == "result"
+        assert operation.call_count == 2
+
+    def test_when_a_connection_error_clears_then_it_should_retry(self, _sleep):
+        operation = MagicMock(side_effect=[ClientConnectionError("net"), "result"])
+        assert zinoargus.call_argus(operation) == "result"
+        assert operation.call_count == 2
+
+    def test_when_auth_error_then_it_should_not_retry(self, _sleep):
+        operation = MagicMock(side_effect=_auth_error())
+        with pytest.raises(AuthError):
+            zinoargus.call_argus(operation)
+        operation.assert_called_once()
+
+    def test_when_client_error_then_it_should_not_retry(self, _sleep):
+        # A 4xx such as 404 won't fix itself, so it propagates without retrying.
+        operation = MagicMock(side_effect=_not_found_error())
+        with pytest.raises(NotFoundError):
+            zinoargus.call_argus(operation)
+        operation.assert_called_once()
+
+    def test_when_transient_errors_exhaust_attempts_then_it_should_reraise(
+        self, _sleep
+    ):
+        operation = MagicMock(side_effect=_server_error())
+        with pytest.raises(ServerError):
+            zinoargus.call_argus(operation)
+        assert operation.call_count == zinoargus.ARGUS_RETRY_ATTEMPTS
 
 
 @patch("zinoargus.time.sleep")


### PR DESCRIPTION
The glue service exits on the first error from either side. There is no reconnect loop — the handlers in `main()` logged "retrying" but then fell through and let the process exit — and the individual Argus/Zino calls in the event loop are unguarded, so a single REST blip or a dropped Zino connection kills the service. In production a momentary Argus 5xx or a brief network hiccup takes the bridge down until someone restarts it.

This keeps the service running through transient faults, split along the grain of the two protocols. The Zino protocol is stateful, so a lost connection is handled by an outer supervisor loop ([`run_supervised()`](https://github.com/Uninett/zino-argus-glue/blob/9dc311a88e87828211e1a801922cfbbf84ca7fff/src/zinoargus/__init__.py#L125)) that reconnects with exponential backoff and re-syncs. Argus is a stateless REST API, so transient errors (5xx, network) are retried in place ([`call_argus()`](https://github.com/Uninett/zino-argus-glue/blob/9dc311a88e87828211e1a801922cfbbf84ca7fff/src/zinoargus/__init__.py#L214)) and the event-loop boundaries log-and-skip on exhaustion, so one bad incident never tears down the connection. A non-auth 4xx (e.g. a 404 for an incident deleted server-side) is skipped rather than escalated to a Zino reconnect. Authentication failures on either side stay fatal, since retrying a bad credential cannot succeed.

Idempotent Argus reads are retried; writes are deliberately left unwrapped to avoid duplicate events and instead self-heal on the next cycle. The circuit-metadata fetch is intentionally left untouched here — it's unimplemented and should be hardened when that feature is actually built, not in this bugfix. The commits are focused and build on each other, so it's probably best reviewed commit-by-commit.

One known limitation: a brand-new case whose Argus incident creation hits a transient error is only retried on its next Zino notification or the next full re-sync after a reconnect, not re-driven by the periodic refresh — flagged as a possible follow-up.
