### PR TITLE
Set Argus incident severity from Zino case priority

### DIFF
--- a/changelog.d/35.added.md
+++ b/changelog.d/35.added.md
@@ -1,0 +1,1 @@
+Map Zino case priority to Argus incident severity level via the new `[sync.severity]` configuration

--- a/src/zinoargus/__init__.py
+++ b/src/zinoargus/__init__.py
@@ -653,11 +653,37 @@ def create_argus_incident(zino_case: ritz.Case):
         end_time=datetime.max,
         source_incident_id=zino_case.id,
         description=description,
+        level=resolve_severity(zino_case),
         tags=dict(generate_tags(zino_case)),
     )
     incident = _argus.post_incident(incident)
     synchronize_case_history(zino_case, incident)
     return incident
+
+
+def resolve_severity(zino_case: ritz.Case) -> int:
+    """Resolve the Argus incident level for a Zino case.
+
+    Maps the case's Zino ``priority`` (higher is more important) to an Argus
+    ``level`` (1=Critical .. 5=Information; lower is more severe) using the
+    configured severity bands. When no band matches the priority, the configured
+    ``default`` level is returned, so every incident always gets an explicit
+    level.
+    """
+    severity = _config.sync.severity
+
+    # priority is forced to int by zinolib on case load, so the isinstance
+    # guard is belt-and-suspenders rather than a routine code path. A None
+    # check would be dead code: zinolib's Case.__getattr__ returns the Case
+    # itself for absent attributes, never None.
+    priority = zino_case.priority
+    if not isinstance(priority, int):
+        return severity.default
+
+    for band in sorted(severity.thresholds, key=lambda b: b.min_priority, reverse=True):
+        if priority >= band.min_priority:
+            return band.level
+    return severity.default
 
 
 def setup_logging(verbosity: int = 0):

--- a/src/zinoargus/config/models.py
+++ b/src/zinoargus/config/models.py
@@ -16,9 +16,16 @@
 
 """Zino configuration models"""
 
-from typing import Literal, Optional, Union
+from typing import List, Literal, Optional, Union
 
-from pydantic import AnyHttpUrl, BaseModel, ConfigDict, IPvAnyAddress, PositiveFloat
+from pydantic import (
+    AnyHttpUrl,
+    BaseModel,
+    ConfigDict,
+    Field,
+    IPvAnyAddress,
+    PositiveFloat,
+)
 
 Host = Union[IPvAnyAddress, str]
 
@@ -72,6 +79,36 @@ class TicketSyncConfiguration(BaseModel):
     enable: bool = False
 
 
+class SeverityBand(BaseModel):
+    """A single Zino-priority-to-Argus-level mapping band.
+
+    A case is assigned this band's Argus ``level`` when its Zino ``priority``
+    is greater than or equal to ``min_priority``.
+    """
+
+    # throw ValidationError on extra keys
+    model_config = ConfigDict(extra="forbid")
+
+    min_priority: int = Field(ge=0)
+    # Argus levels run 1 (Critical) to 5 (Information); lower is more severe.
+    level: int = Field(ge=1, le=5)
+
+
+class SeverityConfiguration(BaseModel):
+    """Class for modeling Argus incident severity mapping configuration.
+
+    Maps a Zino case's ``priority`` (higher means more important) to an Argus
+    incident ``level`` (1=Critical .. 5=Information; lower means more severe).
+    """
+
+    # throw ValidationError on extra keys
+    model_config = ConfigDict(extra="forbid")
+
+    # Argus level used when a case's priority is below every configured band.
+    default: int = Field(default=3, ge=1, le=5)
+    thresholds: List[SeverityBand] = Field(default_factory=list)
+
+
 class SyncConfiguration(BaseModel):
     """Class for modeling synchronization behavior configuration"""
 
@@ -80,6 +117,10 @@ class SyncConfiguration(BaseModel):
 
     acknowledge: Optional[AcknowledgeSyncConfiguration] = AcknowledgeSyncConfiguration()
     ticket: Optional[TicketSyncConfiguration] = TicketSyncConfiguration()
+    # Severity mapping is always active: an absent [sync.severity] block yields
+    # these defaults, so every Argus incident gets an explicit level (3/Moderate
+    # by default) rather than relying on Argus's own server-side default.
+    severity: SeverityConfiguration = SeverityConfiguration()
 
 
 class FailoverConfiguration(BaseModel):

--- a/tests/config/test_models.py
+++ b/tests/config/test_models.py
@@ -1,7 +1,11 @@
 import pydantic
 import pytest
 
-from zinoargus.config.models import Configuration, FailoverConfiguration
+from zinoargus.config.models import (
+    Configuration,
+    FailoverConfiguration,
+    SeverityConfiguration,
+)
 
 
 def test_when_configuration_is_empty_it_should_not_validate():
@@ -38,3 +42,61 @@ class TestConfigurationFailover:
             },
         )
         assert config.failover is None
+
+
+class TestConfigurationSeverity:
+    def test_when_severity_absent_it_should_default_to_level_3(self):
+        config = Configuration(
+            argus={"url": "https://argus.example.org/api/v2", "token": "secret"},
+            zino={
+                "server": "zino.example.org",
+                "user": "zinouser",
+                "secret": "secret",
+            },
+        )
+        assert config.sync.severity is not None
+        assert config.sync.severity.default == 3
+        assert config.sync.severity.thresholds == []
+
+
+class TestSeverityConfiguration:
+    def test_when_valid_block_given_it_should_validate(self):
+        config = SeverityConfiguration(
+            default=4,
+            thresholds=[
+                {"min_priority": 500, "level": 1},
+                {"min_priority": 100, "level": 3},
+            ],
+        )
+        assert config.default == 4
+        assert config.thresholds[0].min_priority == 500
+        assert config.thresholds[0].level == 1
+        assert config.thresholds[1].min_priority == 100
+        assert config.thresholds[1].level == 3
+
+    def test_when_block_is_empty_it_should_use_defaults(self):
+        config = SeverityConfiguration()
+        assert config.default == 3
+        assert config.thresholds == []
+
+    def test_when_default_out_of_range_it_should_not_validate(self):
+        with pytest.raises(pydantic.ValidationError):
+            SeverityConfiguration(default=6)
+
+    def test_when_level_out_of_range_it_should_not_validate(self):
+        with pytest.raises(pydantic.ValidationError):
+            SeverityConfiguration(thresholds=[{"min_priority": 100, "level": 0}])
+
+    def test_when_min_priority_negative_it_should_not_validate(self):
+        with pytest.raises(pydantic.ValidationError):
+            SeverityConfiguration(thresholds=[{"min_priority": -1, "level": 1}])
+
+    def test_when_extra_field_given_it_should_not_validate(self):
+        with pytest.raises(pydantic.ValidationError):
+            SeverityConfiguration(bogus="value")
+
+    def test_when_band_has_extra_field_it_should_not_validate(self):
+        with pytest.raises(pydantic.ValidationError):
+            SeverityConfiguration(
+                thresholds=[{"min_priority": 100, "level": 1, "bogus": "value"}]
+            )

--- a/tests/test_zinoargus.py
+++ b/tests/test_zinoargus.py
@@ -1,14 +1,110 @@
 import subprocess
 import time
+from datetime import datetime
+from types import SimpleNamespace
 
 import pytest
 
-from zinoargus import is_down_log
+import zinoargus
+from zinoargus import is_down_log, resolve_severity
+from zinoargus.config.models import SeverityConfiguration
 
 
 @pytest.mark.parametrize("log_message", ["linkDown", "lowerLayerDown", "up to down"])
 def test_when_log_message_indicates_down_events_it_should_return_true(log_message):
     assert is_down_log(log_message)
+
+
+class TestResolveSeverity:
+    BANDS = [
+        {"min_priority": 500, "level": 1},
+        {"min_priority": 300, "level": 2},
+        {"min_priority": 100, "level": 3},
+        {"min_priority": 1, "level": 4},
+    ]
+
+    def _configure_severity(self, monkeypatch, severity):
+        config = SimpleNamespace(sync=SimpleNamespace(severity=severity))
+        monkeypatch.setattr(zinoargus, "_config", config)
+
+    def test_when_priority_above_top_band_then_it_should_return_level_1(
+        self, monkeypatch
+    ):
+        self._configure_severity(
+            monkeypatch, SeverityConfiguration(default=5, thresholds=self.BANDS)
+        )
+        assert resolve_severity(SimpleNamespace(priority=1000)) == 1
+
+    def test_when_priority_in_mid_band_then_it_should_return_matching_level(
+        self, monkeypatch
+    ):
+        self._configure_severity(
+            monkeypatch, SeverityConfiguration(default=5, thresholds=self.BANDS)
+        )
+        assert resolve_severity(SimpleNamespace(priority=350)) == 2
+
+    def test_when_priority_equals_band_minimum_then_it_should_return_that_level(
+        self, monkeypatch
+    ):
+        self._configure_severity(
+            monkeypatch, SeverityConfiguration(default=5, thresholds=self.BANDS)
+        )
+        assert resolve_severity(SimpleNamespace(priority=500)) == 1
+        assert resolve_severity(SimpleNamespace(priority=100)) == 3
+
+    def test_when_priority_below_lowest_band_then_it_should_return_default(
+        self, monkeypatch
+    ):
+        self._configure_severity(
+            monkeypatch, SeverityConfiguration(default=5, thresholds=self.BANDS)
+        )
+        assert resolve_severity(SimpleNamespace(priority=0)) == 5
+
+    def test_when_thresholds_empty_then_it_should_return_default(self, monkeypatch):
+        self._configure_severity(
+            monkeypatch, SeverityConfiguration(default=2, thresholds=[])
+        )
+        assert resolve_severity(SimpleNamespace(priority=1000)) == 2
+
+    def test_when_priority_not_an_int_then_it_should_return_default(self, monkeypatch):
+        self._configure_severity(
+            monkeypatch, SeverityConfiguration(default=4, thresholds=self.BANDS)
+        )
+        assert resolve_severity(SimpleNamespace(priority="bogus")) == 4
+
+
+class TestCreateArgusIncident:
+    def test_when_severity_configured_then_it_should_pass_resolved_level(
+        self, monkeypatch
+    ):
+        config = SimpleNamespace(
+            sync=SimpleNamespace(
+                severity=SeverityConfiguration(
+                    default=5, thresholds=[{"min_priority": 100, "level": 2}]
+                )
+            )
+        )
+        monkeypatch.setattr(zinoargus, "_config", config)
+        monkeypatch.setattr(zinoargus, "describe_zino_case", lambda case: "down")
+        monkeypatch.setattr(zinoargus, "generate_tags", lambda case: iter(()))
+        monkeypatch.setattr(
+            zinoargus, "synchronize_case_history", lambda case, inc: None
+        )
+
+        captured = {}
+
+        def fake_post_incident(incident):
+            captured["incident"] = incident
+            return incident
+
+        monkeypatch.setattr(
+            zinoargus, "_argus", SimpleNamespace(post_incident=fake_post_incident)
+        )
+
+        case = SimpleNamespace(id=1, opened=datetime(2026, 1, 1), priority=200)
+        zinoargus.create_argus_incident(case)
+
+        assert captured["incident"].level == 2
 
 
 @pytest.mark.slow

--- a/zinoargus.toml.example
+++ b/zinoargus.toml.example
@@ -27,6 +27,33 @@ acknowledge.setstate = "none"
 # entries.  Set this to `true` to do so:
 ticket.enable = false
 
+# Mapping of Zino case priority to Argus incident severity level.  Every
+# incident is assigned an explicit Argus level; the `default` below applies
+# when no threshold band matches (or when no bands are configured at all).
+#
+# Zino priority is an open-ended integer (higher means more important); Argus
+# level is 1-5 where 1=Critical, 2=High, 3=Moderate, 4=Low, 5=Information
+# (lower means more severe).  Note that the two scales run in opposite
+# directions: a high Zino priority maps to a low Argus level.
+[sync.severity]
+# Argus level assigned when a case's Zino priority is below every band below.
+default = 3
+#
+# Each band maps a minimum Zino priority to an Argus level.  A case is assigned
+# the level of the highest band whose min_priority its Zino priority meets.
+#[[sync.severity.thresholds]]
+#min_priority = 500   # Zino priority >= 500 -> Argus level 1 (Critical)
+#level = 1
+#[[sync.severity.thresholds]]
+#min_priority = 300   # Zino priority >= 300 -> Argus level 2 (High)
+#level = 2
+#[[sync.severity.thresholds]]
+#min_priority = 100   # Zino priority >= 100 -> Argus level 3 (Moderate)
+#level = 3
+#[[sync.severity.thresholds]]
+#min_priority = 1     # Zino priority >= 1   -> Argus level 4 (Low)
+#level = 4
+
 # Circuit metadata from telemator. NOT currently usable: the fetch is unguarded,
 # so a slow or unavailable endpoint will crash the glue service. Leave this
 # commented out until the metadata feature is actually implemented.


### PR DESCRIPTION
Argus incidents created by the glue were posted without an explicit severity `level`, so every incident inherited Argus's server-side default and operators had no way to tell a backbone router going dark apart from a minor edge-port flap. This adds a configurable mapping from a Zino case's `priority` (higher means more important) to an Argus incident `level` (1=Critical … 5=Information; lower means more severe), and applies it to every incident the glue creates.

The mapping is always active. A new `[sync.severity]` block defines a `default` level (3/Moderate out of the box) plus any number of threshold bands; a case is assigned the level of the highest band whose minimum priority it meets, falling back to `default` when no band matches. With no bands configured every incident simply gets `default` — already an improvement over Argus's own default, because the value is now explicit and operator-controlled.

The two scales run in opposite directions — a high Zino priority maps to a low, more severe Argus level — so the [example configuration](https://github.com/Uninett/zino-argus-glue/blob/abc973b363fba724caac597e02e883b584497b40/zinoargus.toml.example) spells both out side by side to avoid the potential foot-gun. The level is derived from priority in [`resolve_severity()`](https://github.com/Uninett/zino-argus-glue/blob/abc973b363fba724caac597e02e883b584497b40/src/zinoargus/__init__.py#L664).
